### PR TITLE
Updated typo in the documentation tutorial

### DIFF
--- a/docs/tutorial/Importing_biorefineries.ipynb
+++ b/docs/tutorial/Importing_biorefineries.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Importing bioferineries"
+    "# Importing biorefineries"
    ]
   },
   {
@@ -307,9 +307,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Hi all,

I found a typo in the documentation (Tutorial 11. Importing _bioferineries_ -> changed to _biorefineries_)

Great project!

Best regards,
Rupert