### PR TITLE
Fix KS test

### DIFF
--- a/biosteam/evaluation/_model.py
+++ b/biosteam/evaluation/_model.py
@@ -17,8 +17,6 @@ from ._state import State
 from ._metric import Metric
 from ._parameter import Parameter
 from ._utils import var_indices, var_columns, indices_to_multiindex
-from ..utils import format_title
-import biosteam as bst
 from biosteam.exceptions import FailedEvaluation
 from warnings import warn
 from collections.abc import Sized
@@ -547,10 +545,18 @@ class Model(State):
         from scipy.stats import kendalltau
         return self._correlation(kendalltau, parameters, metrics, filter, kwargs)
     
-    def kolmogorov_smirnov_d(self, parameters=None, metrics=None, filter=None, **kwargs):
+    def kolmogorov_smirnov_d(self, parameters=None, metrics=None, thresholds=[],
+                             filter=None, **kwargs):
         """
-        Return two DataFrame objects of Kolmogorov–Smirnov's D and p-values 
-        between metrics and parameters.
+        Return two DataFrame objects of Kolmogorov–Smirnov's D and p-values
+        with the given thresholds for the metrics.
+        
+        For one particular parameter, all of the sampled values will be divided into two sets,
+        one where the resulting metric value is smaller than or equal to the threshold,
+        and the other where the resulting value is larger than the threshold.
+        
+        Kolmogorov–Smirnov test will then be performed for these two sets of values
+        for the particular parameter.
         
         Parameters
         ----------
@@ -558,6 +564,8 @@ class Model(State):
             Parameters to be correlated with metrics. Defaults to all parameters.
         metrics : Iterable[Metric], optional 
             Metrics to be correlated with parameters. Defaults to all metrics.
+        thresholds : Iterable[float]
+            The
             
         Other Parameters
         ----------------
@@ -583,6 +591,11 @@ class Model(State):
         
         """
         from scipy.stats import kstest
+        metrics = metrics or self.metrics
+        if len(thresholds) != len(metrics):
+            raise ValueError(f'The number of metrics {len(metrics)} must match '
+                             f'the number of thresholds ({len(thresholds)}).')
+        kwargs['thresholds'] = thresholds
         return self._correlation(kstest, parameters, metrics, filter, kwargs)
     
     def _correlation(self, f, parameters, metrics, filter, kwargs):
@@ -623,6 +636,7 @@ class Model(State):
         parameter_data = [values[index(i)] for i in parameter_indices]
         metric_indices = var_indices(metrics or self.metrics)
         metric_data = [values[index(i)] for i in metric_indices]
+                
         if not filter: filter = 'propagate nan'
         if isinstance(filter, str):
             name = filter.lower()
@@ -654,7 +668,18 @@ class Model(State):
         else: #: pragma: no cover
             raise TypeError("filter must be either a string or a callable; "
                             "not a '{type(filter).__name__}' object")
-        data = np.array([[corr(p, m) for m in metric_data] for p in parameter_data])
+
+        if 'thresholds' not in kwargs:
+            data = np.array([[corr(p, m) for m in metric_data] for p in parameter_data])
+        else: # KS test
+            thresholds = kwargs.pop('thresholds')
+            data = np.array(
+                [
+                    [corr(parameter_data[n_p][metric_data[n_m]<=thresholds[n_m]],
+                          parameter_data[n_p][metric_data[n_m]>thresholds[n_m]]) \
+                     for n_m in range(len(metric_data))] \
+                for n_p in range(len(parameter_data))])
+        
         index = indices_to_multiindex(parameter_indices, ('Element', 'Parameter'))
         columns = indices_to_multiindex(metric_indices, ('Element', 'Metric'))        
         return [pd.DataFrame(i, index=index, columns=columns) for i in (data[..., 0], data[..., 1])]

--- a/biosteam/evaluation/_model.py
+++ b/biosteam/evaluation/_model.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # BioSTEAM: The Biorefinery Simulation and Techno-Economic Analysis Modules
-# Copyright (C) 2020-2021, Yoel Cortes-Pena <yoelcortes@gmail.com>
+# Copyright (C) 2020-2021, Yoel Cortes-Pena <yoelcortes@gmail.com>,
+#                          Yalin Li <zoe.yalin.li@gmail.com>
 #
 # This module implements a filtering feature from the stats module of the QSDsan library:
 # QSDsan: Quantitative Sustainable Design for sanitation and resource recovery systems


### PR DESCRIPTION
I just realized that the `kolmogorov_smirnov_d` method in `Model` is not implemented correctly. KS test is different from Spearman, Pearson, etc. in that it's not directly comparing parameters and metrics. Instead, you should have a threshold or some sort to separate the parameters into two sets, then you use these two sets of parameter values in the test.

For example, in the cornstover biorefinery, we may want to use KS test for fermentation yield and MESP. Assuming we set the threshold at $2.15/gal, then based on the Monte Carlo results, we separate the fermentation yield into two sets: one that can result in an MESP of $2.15/gal or smaller, and one that lead to greater than $2.15/gal. Then we should pass these two sets of parameters to the function in `scipy`.

So I updated the module to work this way, and I tested with the following code:
```python
import numpy as np, biosteam as bst
from chaospy import distributions as shape

chems = bst.Chemicals((bst.Chemical('H2O'), bst.Chemical('Ethanol')))
bst.settings.set_thermo(chems)

s1 = bst.Stream('s1', H2O=100)
M1 = bst.MixTank(ins=s1)
M2 = bst.MixTank(ins=M1-0)
sys = bst.System('sys', path=(M1, M2))

model = bst.Model(sys)

baseline = 1
distribution = shape.Uniform(lower=0.5, upper=1.5)
@model.parameter(name='M1 tau', element=M1, kind='coupled', distribution=distribution,
                 units='hr', baseline=baseline)
def set_M1_tau(i):
    M1.tau = i
    
baseline = 1.75
distribution = shape.Uniform(lower=1, upper=2)
@model.parameter(name='M2 tau', element=M2, kind='coupled', distribution=distribution,
                 units='hr', baseline=baseline)
def set_M2_tau(i):
    M2.tau = i

model.metrics = [
    bst.Metric(name='tau1', getter=lambda: M1.tau, units='hr', element=M1),
    bst.Metric(name='tau2', getter=lambda: M2.tau, units='hr', element=M2),
    ]

np.random.seed(3221)
samples = model.sample(100, rule='L')
model.load_samples(samples)
model.evaluate()

D, p = model.kolmogorov_smirnov_d(thresholds=[1, 1.5])

print(D, '\n')
print(p)
```

Here's what I got:
```
Element                 Mix tank-T1 Mix tank-T2
Metric                    tau1 [hr]   tau2 [hr]
Element     Parameter                          
Mix tank-T1 M1 tau [hr]           1        0.14
Mix tank-T2 M2 tau [hr]        0.12           1 

Element                 Mix tank-T1 Mix tank-T2
Metric                    tau1 [hr]   tau2 [hr]
Element     Parameter                          
Mix tank-T1 M1 tau [hr]    1.98e-29       0.717
Mix tank-T2 M2 tau [hr]       0.869    1.98e-29
```

I hope I understand/implemented this corrected, @joyxyz1994 @yoelcortes feel free to correct/update, thanks!

