### PR TITLE
Better Graphviz error handling

### DIFF
--- a/biosteam/digraph/digraph.py
+++ b/biosteam/digraph/digraph.py
@@ -333,7 +333,11 @@ def finalize_digraph(digraph, file, format): # pragma: no coverage
         try:
             if file: save_digraph(digraph, file, format)
             else: display_digraph(digraph, format)
-        except Exception as exp: 
+        except Exception as exp:
+            from os import path
+            file_dir = path.split(file)[0]
+            if not path.isdir(file_dir):
+                raise FileNotFoundError(f'The designated path "{file_dir}" does not exist.')
             warn(
                 f"a '{type(exp).__name__}' was raised when generating "
                 "graphviz diagram, possibly due to graphviz installation issues",


### PR DESCRIPTION
Currently, when saving unit/system diagrams to a directory that does not exist (e.g., a typo in the path), BioSTEAM raises an error about Graphviz's installation warning, e.g.,
```python
from biorefineries import cornstover as cs
cs.R201.diagram(dpi='300', file='non-existing-path/x.png')
```

![Screen Shot 2022-02-22 at 10 00 00 AM](https://user-images.githubusercontent.com/49011373/155170442-21f3e934-1656-4683-a190-2e5ff3c1c68a.png)

Which can be confusing, so I tried to fix it by firstly examining if the directory exists, now the message will be

![Screen Shot 2022-02-22 at 10 01 52 AM](https://user-images.githubusercontent.com/49011373/155170773-1df2de89-5008-4838-ae5c-91793fa814e8.png)

However, I'm not sure if it'll be better to move this path examination to the top of this function, so this `FileNotFoundError` won't appear twice.

Thanks!