### PR TITLE
add `dynsim_kwargs` attr for `System`

### DIFF
--- a/biosteam/evaluation/_model.py
+++ b/biosteam/evaluation/_model.py
@@ -10,8 +10,7 @@
 # This module is under the UIUC open-source license. See 
 # github.com/BioSTEAMDevelopmentGroup/biosteam/blob/master/LICENSE.txt
 # for license details.
-"""
-"""
+
 import numpy as np
 import pandas as pd
 from ._state import State
@@ -39,7 +38,7 @@ class Model(State):
     metrics : tuple[Metric]
         Metrics to be evaluated by model.
     specification=None : Function, optional
-        Loads speficications once all parameters are set. Specification should 
+        Loads specifications once all parameters are set. Specification should 
         simulate the system as well.
     params=None : Iterable[Parameter], optional
         Parameters to sample from.

--- a/biosteam/evaluation/_parameter.py
+++ b/biosteam/evaluation/_parameter.py
@@ -101,8 +101,8 @@ class Parameter(Variable):
             unit = self.unit
             return system._downstream_system(unit) if unit else system
     
-    def simulate(self, **kwargs):
-        """Simulate paramater."""
+    def simulate(self, **dyn_sim_kwargs):
+        """Simulate parameter."""
         kind = self.kind
         if kind in ('design', 'cost'):
             unit = self.unit
@@ -111,7 +111,7 @@ class Parameter(Variable):
         elif kind == 'coupled':
             subsystem = self.subsystem
             if not subsystem: raise RuntimeError(f'no system to run {kind} algorithm')
-            self.subsystem.simulate(**kwargs)
+            self.subsystem.simulate(**dyn_sim_kwargs)
         elif kind == 'isolated':
             pass
         else:
@@ -129,6 +129,3 @@ class Parameter(Variable):
              + (f' units: {self.units}\n' if self.units else '')
              + (f' distribution: {self.distribution}\n' if self.distribution else ''))
     
-                
-    
-               

--- a/biosteam/evaluation/_state.py
+++ b/biosteam/evaluation/_state.py
@@ -80,7 +80,7 @@ class State:
     ----------
     system : System
     specification=None : Function, optional
-        Loads speficications once all parameters are set.
+        Loads specifications once all parameters are set.
     parameters=None : Iterable[Parameter], optional
         Parameters to sample from.
     
@@ -88,7 +88,7 @@ class State:
     __slots__ = ('_system', # [System]
                  '_parameters', # list[Parameter] All parameters.
                  '_N_parameters_cache', # [int] Number of parameters previously loaded
-                 '_specification', # [function] Loads speficications once all parameters are set.
+                 '_specification', # [function] Loads specifications once all parameters are set.
                  '_sample_cache') # [1d array] Last sample evaluated.
     
     load_default_parameters = load_default_parameters


### PR DESCRIPTION
As we discussed, I added `dynsim_kwargs` as an attribute to `System`, All qsdsan's tests and biosteam's qsdsan test passed locally.

@yoelcortes , looks like tests are failing because you are using walrus operators that doesn't exist for Python 3.7, maybe you should change the Python version in README/test env to 3.8/3.9, with the remote tests failing almost all the time we aren't able to tell whether it's because our updates or other problems. Thanks!