### PR TITLE
Rigcol

### DIFF
--- a/biosteam/_unit.py
+++ b/biosteam/_unit.py
@@ -301,8 +301,7 @@ class Unit:
     # [biosteam Graphics] A Graphics object for diagram representation
     _graphics = box_graphics
 
-    # [int] Used for piping warnings. Should be equal to 6 plus the number of
-    # wrappers to Unit.__init__
+    # [int] Used for piping warnings.
     _stacklevel = 5
     
     # [str] The general type of unit, regardless of class


### PR DESCRIPTION
Updates to mixer settlers:

* Allow for feeds at different stages (more than 2 feeds is now possible).
* Allow for extract and raffinate side draws.
* Faster (twice as fast given partition coefficients) simulation by implementing Thomas algorithm for solving tridiagonal matrix (in mass and equilibrium balances).
* Closure of overall mass balance (absolute zero generation/consumption of components regardless or convergence tolerance).
* **Partition data now given in the form of Extract/Raffinate** (instead of Raffinate/Extract).@sarangbhagwat, @yalinli2, you may need to update some biorefineries if you pull the latest biosteam/thermosteam.