### PR TITLE
Fix tests

### DIFF
--- a/tests/test_autogenerated_system.py
+++ b/tests/test_autogenerated_system.py
@@ -638,7 +638,6 @@ def test_sugarcane_ethanol_biorefinery_network():
              P203],
             recycle=P203-0),
          S202,
-         S301,
          F301,
          P306,
          M301,
@@ -672,8 +671,7 @@ def test_sugarcane_ethanol_biorefinery_network():
          T304,
          P303,
          M305,
-         U202,
-         T305])
+         U202])
     assert network == actual_network
     sugarcane_sys.empty_recycles()
     sugarcane_sys.simulate()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -19,7 +19,7 @@ def test_unit_connections():
     assert R301.neighborhood(1) == {T301, D301, S302, H301}
     assert R301.neighborhood(2) == {S302, C301, H301, M302, D301, R301, T301, M301}
     assert R301.neighborhood(100) == R301.neighborhood(1000) == {
-        M305, T304, S301, F301, M301, P302, H301, H302, T204, M303, 
+        M305, T304, F301, M301, P302, H301, H302, T204, M303,
         P201, U101, R301, D303, T301, T205, U102, U103, P202, M202, 
         M302, H202, D301, T206, S202, P303, C201, H303, C301, U301, 
         S302, P203, T203, T302, P301, C202, D302, H304, P304, P306, 


### PR DESCRIPTION
@yoelcortes 
Several tests currently fail:

### in tests folder
- [x] S301 and T305 seem to have been removed from sugarcane network -> fixed by removing references
- [ ] ethanol price changed in [biorefineries.tests.test_biorefineries](https://github.com/BioSTEAMDevelopmentGroup/Bioindustrial-Park/blob/master/biorefineries/tests/test_biorefineries.py#L202)
- [ ] IRR changed in [biorefineries.tests.test_biorefineries](https://github.com/BioSTEAMDevelopmentGroup/Bioindustrial-Park/blob/master/biorefineries/tests/test_biorefineries.py#L222)
- [ ] all three tests in [test_diagrams](https://github.com/BioSTEAMDevelopmentGroup/biosteam/blob/master/tests/test_diagrams.py) are failing
- [ ] `test_qsdsan` fails with `AttributeError: module 'qsdsan.processes' has no attribute 'create_asm1_cmps'` in [this line](https://github.com/BioSTEAMDevelopmentGroup/biosteam/blob/master/tests/test_qsdsan.py#L18)

### in in-code documentation
- [ ] (to be listed)

### in notebooks
- [ ] (to be listed)