### PR TITLE
Fix tests

### DIFF
--- a/biosteam/units/_compressor.py
+++ b/biosteam/units/_compressor.py
@@ -190,7 +190,7 @@ class IsentropicCompressor(Unit):
             self.type = 'Centrifugal'
         else:
             raise RuntimeError(
-                f"power requirement ({power / 1e3:.3g} MW) is above is outside cost "
+                f"power requirement ({power / 1e3:.3g} MW) is outside cost "
                  "correlation range (0, 30 MW). No fallback for this case has "
                  "been implemented yet"
             )

--- a/biosteam/units/_compressor.py
+++ b/biosteam/units/_compressor.py
@@ -66,13 +66,16 @@ class IsentropicCompressor(Unit):
     
     >>> K.results()
     Isentropic compressor                               Units       K1
+    Power               Rate                               kW     7.03
+                        Cost                           USD/hr     0.55
     Design              Power                              kW     7.03
                         Isentropic Power                   kW     4.92
+                        Outlet Temperature                  K 1.15e+03
                         Isentropic Outlet Temperature       K      901
                         Volumetric Flow Rate           m^3/hr     24.5
     Purchase cost       Compressor                        USD 4.94e+03
     Total purchase cost                                   USD 4.94e+03
-    Utility cost                                       USD/hr        0
+    Utility cost                                       USD/hr     0.55
 
     Per default, the outlet pahse is assumed to be the same as the inlet phase. If phase changes are to be accounted for,
     set `vle=True`:
@@ -96,13 +99,17 @@ class IsentropicCompressor(Unit):
     
     >>> K.results()
     Isentropic compressor                               Units       K2
+    Power               Rate                               kW     5.41
+                        Cost                           USD/hr    0.423
     Design              Power                              kW     5.41
                         Isentropic Power                   kW     5.41
+                        Outlet Temperature                  K      798
                         Isentropic Outlet Temperature       K      798
                         Volumetric Flow Rate           m^3/hr     27.9
     Purchase cost       Compressor                        USD 5.01e+03
     Total purchase cost                                   USD 5.01e+03
-    Utility cost                                       USD/hr        0
+    Utility cost                                       USD/hr    0.423
+
 
     References
     ----------

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER ELLIPSIS
-addopts = --ignore='setup.py docs/conf.py' --doctest-modules --nbval
+addopts = --ignore='setup.py docs/conf.py' --doctest-modules --nbval --current-env
 norecursedirs = .egg-info .cache .git htmlcov notebooks dist opt site-packages docs/_build .ipynb_checkpoints thermosteam
 filterwarnings = ignore
 markers =


### PR DESCRIPTION
Continuation of https://github.com/BioSTEAMDevelopmentGroup/biosteam/pull/104

- fix `IsentropicCompressor` docstring and typo in error message
- add `--current-env` flag to pytest.ini to ensure nbval executes in correct environment