### PR TITLE
Introduce skip_setup flag for two-paced convergence

### DIFF
--- a/biosteam/_system.py
+++ b/biosteam/_system.py
@@ -1837,7 +1837,7 @@ class System:
             ws.state = y*0.0
             ws.dstate = y*0.0
 
-    def simulate(self, **kwargs):
+    def simulate(self, skip_setup=False, **kwargs):
         """
         If system is dynamic, run the system dynamically. Otherwise, converge 
         the path of unit operations to steady state. After running/converging 
@@ -1851,7 +1851,8 @@ class System:
         
         """
         self._configuration_updated = False
-        self._setup()
+        if not skip_setup:
+            self._setup()
         if self.isdynamic: 
             self.dynamic_run(**kwargs)
             self._summary()


### PR DESCRIPTION
This PR introduces a `skip_setup` flag into the `System.simulate()` function. Skipping the setup can be useful if a system is to be simulated twice - first time with options that will guarantee convergence but might be inaccurate and a second time to improve accuracy. For example simulating nitrogen liquefaction:

```python
import biosteam as bst

# setup thermodynamic backend
bst.settings.set_thermo(["N2"])
bst.settings.mixture.include_excess_energies = True
bst.settings.chemicals["N2"].reset_free_energies()

# inlet
inlet = bst.Stream("inlet", N2=2.75, units="kg/s", T=6.85+273.15, P=200e5, phase="g")

# recycle HX
regenerator = bst.units.HXprocess("regenerator", ins=(inlet, "flash_gas"), outs=("throttle_in", 'out'), dT=9.55)
throttle_in = regenerator.outs[0]

# throttling
valve = bst.units.IsenthalpicValve("expansion", ins=throttle_in, outs="valve_out", P=1e5, vle=True)
valve_out = valve.outs[0]

# flash drum
flash = bst.units.Flash("flash", ins=valve_out, outs=("flash_gas", "flash_liquid"), Q=0, P=1e5)
gas_out = flash.outs[0]
liquid_out = flash.outs[1]

# connect flash gas to regenerator
regenerator.ins[1] = gas_out

# run simulation
sys = bst.main_flowsheet.create_system('flowsheet_sys')
sys.simulate()

# the simulation converged but the result is inaccurate
print(regenerator.outs[0].show())

"""
MultiStream: throttle_in from <HXprocess: regenerator> to <IsenthalpicValve: expansion>
 phases: ('g', 'l'), T: 168.77 K, P: 2e+07 Pa
 flow (kmol/hr): (g) N2  345
                 (l) N2  8.62
"""

# coolprop methods are more accurate but using them from the start is not possible because the system would not converge
bst.settings.chemicals["N2"].Cn.g.method = "COOLPROP"
bst.settings.chemicals["N2"].Cn.l.method = "COOLPROP"
bst.settings.chemicals["N2"].reset_free_energies()
sys.simulate(skip_setup=True)

# this result is more accurate
print(regenerator.outs[0].show())
"""
Stream: throttle_in from <HXprocess: regenerator> to <IsenthalpicValve: expansion>
 phase: 'l', T: 126.2 K, P: 2e+07 Pa
 flow (kmol/hr): N2  353
"""
```