### PR TITLE
avoid renaming heat exchangers and compressors

### DIFF
--- a/biosteam/units/compressor.py
+++ b/biosteam/units/compressor.py
@@ -831,8 +831,8 @@ class MultistageCompressor(Unit):
                 raise RuntimeError(f"invalid parameterization of {self.ID}: `compressors` and `hxs` "
                                    f"must have the same length.")
             else:
-                self.compressors = compressors
-                self.hxs = hxs
+                self.compressors = tuple(compressors)
+                self.hxs = tuple(hxs)
                 self.pr = None
                 self.n_stages = None
 
@@ -894,8 +894,8 @@ class MultistageCompressor(Unit):
         # setup option 2: create connected compressor and hx objects
         else:
             T = feed.T
-            self.compressors = compressors = []
-            self.hxs = hxs = []
+            compressors = []
+            hxs = []
             
             # Temporarily register all units/streams in this flowsheet 
             # (instead of the main flowsheet) to prevent system creation problems
@@ -916,6 +916,8 @@ class MultistageCompressor(Unit):
                     self._overwrite_subcomponent_id(hx, n+1)
                     compressors.append(c)
                     hxs.append(hx)
+            self.compressors = compressors = tuple(compressors)
+            self.hxs =  hxs = tuple(hxs)
 
         # set inlet and outlet reference
         compressors[0]._ins = self._ins

--- a/biosteam/units/compressor.py
+++ b/biosteam/units/compressor.py
@@ -900,7 +900,7 @@ class MultistageCompressor(Unit):
                 self._overwrite_subcomponent_id(hx, n+1)
 
         # setup option 2: create connected compressor and hx objects
-        elif compressors and hxs and pr is not None and n_stages is not None:
+        elif pr is not None and n_stages is not None:
             T = feed.T
             self.compressors = []
             self.hxs = []

--- a/biosteam/units/compressor.py
+++ b/biosteam/units/compressor.py
@@ -878,8 +878,8 @@ class MultistageCompressor(Unit):
         hxs = self.hxs
         pr = self.pr
         n_stages = self.n_stages
-        new_specifications = (pr, n_stages, compressors, hxs)
-        if (new_specifications == self._old_specifications):
+        specifications = (pr, n_stages, compressors, hxs)
+        if (specifications == self._old_specifications):
             return # Skip setup (already done)
         
         # setup option 1: rewire compressors and heat exchangers
@@ -894,8 +894,8 @@ class MultistageCompressor(Unit):
         # setup option 2: create connected compressor and hx objects
         else:
             T = feed.T
-            self.compressors = []
-            self.hxs = []
+            self.compressors = compressors = []
+            self.hxs = hxs = []
             
             # Temporarily register all units/streams in this flowsheet 
             # (instead of the main flowsheet) to prevent system creation problems
@@ -914,18 +914,18 @@ class MultistageCompressor(Unit):
                         ins=c.outs[0], T=T, rigorous=self.vle
                     )
                     self._overwrite_subcomponent_id(hx, n+1)
-                    self.compressors.append(c)
-                    self.hxs.append(hx)
+                    compressors.append(c)
+                    hxs.append(hx)
 
         # set inlet and outlet reference
-        self.compressors[0]._ins = self._ins
-        self.hxs[-1]._outs = self._outs
+        compressors[0]._ins = self._ins
+        hxs[-1]._outs = self._outs
 
         # set auxillary units
-        units = [u for t in zip(self.compressors, self.hxs) for u in t]
+        units = [u for t in zip(compressors, hxs) for u in t]
         self.auxiliary_unit_names = tuple([u.ID for u in units])
         for u in units: self.__setattr__(u.ID, u)
-        self._old_specifications = new_specifications
+        self._old_specifications = (pr, n_stages, compressors, hxs)
 
     def _run(self):
         # calculate results

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -363,7 +363,21 @@ def test_multistage_setup_does_not_recreate_subcomponents():
     K._setup()
     b = K.compressors[0]
     assert a==b
-    pass
+    
+def test_multistage_setup_updates_after_changing_specifications():
+    bst.settings.set_thermo(["H2"])
+    feed = bst.Stream("feed", H2=1, T=25 + 273.15, P=20e5, phase='g')
+    P = 350e5
+    n_stages = 5
+    pr = (P / feed.P) ** (1 / n_stages)
+    K = bst.units.MultistageCompressor(ins=feed, outs=('outlet'), pr=pr, n_stages=n_stages, eta=0.7)
+    K._setup()
+    units_5 = (K.compressors, K.hxs)
+    for i in units_5: assert len(i) == 5
+    K.n_stages = 6
+    K._setup()
+    units_6 = (K.compressors, K.hxs)
+    for i in units_6: assert len(i) == 6
 
 
 if __name__ == '__main__':
@@ -375,3 +389,4 @@ if __name__ == '__main__':
     test_multistage_hydrogen_compressor_simple()
     test_multistage_hydrogen_compressor_advanced()
     test_multistage_setup_does_not_recreate_subcomponents()
+    test_multistage_setup_updates_after_changing_specifications()


### PR DESCRIPTION
Hi @BenPortner,

I made some enhancements to the compressor setup code to prevent unit operations from being renamed/recreated (this should make System.setup() faster). I just wanted to run it by you if case I missed anything. I also removed a bit of code that is not needed anymore in the for loops (since we have `self.compressors[0]._ins = self._ins` and `self.hxs[-1]._outs = self._outs` at the end of setup).

Thanks!