### PR TITLE
fix issue for bioindustrial-park #46

### DIFF
--- a/biosteam/units/solids_separation.py
+++ b/biosteam/units/solids_separation.py
@@ -53,7 +53,7 @@ class SolidsSeparator(Splitter):
     ----------
     ins : streams
         Inlet fluids with solids.
-    outs : stream sequnece
+    outs : stream sequence
         * [0] Retentate.
         * [1] Permeate.
     split : array_like
@@ -273,7 +273,7 @@ RVF = RotaryVacuumFilter
 class CrushingMill(SolidsSeparator):
     """
     Create crushing mill unit operation for the 
-    separation of sugarcane juice from the baggasse.
+    separation of sugarcane juice from the bagasse.
     
     Parameters
     ----------
@@ -286,7 +286,7 @@ class CrushingMill(SolidsSeparator):
     split : array_like or dict[str, float]
         Splits of chemicals to the bagasse.
     moisture_content : float
-                       Fraction of water in Baggasse.
+                       Fraction of water in Bagasse.
     
     """
 
@@ -334,7 +334,7 @@ class PressureFilter(SolidsSeparator):
         * [0] Retentate (i.e. solids)
         * [1] Filtrate
     split : array_like or dict[str, float]
-        Splits of chemicals to the retantate. Defaults to values used in
+        Splits of chemicals to the retentate. Defaults to values used in
         the 2011 NREL report on cellulosic ethanol as given in [2]_.
     moisture_content : float, optional
         Moisture content of retentate. Defaults to 0.35
@@ -345,8 +345,8 @@ class PressureFilter(SolidsSeparator):
     def __init__(self, ID='', ins=None, outs=(), thermo=None, *, 
                  moisture_content=0.35, split=None):
         self._load_thermo(thermo)
-        chemicals = self.chemicals
         if split is None:
+            chemicals = self.chemicals
             split = dict(
                 Furfural=0.03571,
                 Glycerol=0.03714,

--- a/biosteam/units/wastewater.py
+++ b/biosteam/units/wastewater.py
@@ -342,10 +342,11 @@ class SludgeCentrifuge(SolidsSeparator):
     """
     purchase_cost = installation_cost = 0
     def __init__(self, ID='', ins=None, outs=(), thermo=None, *, 
-                 split=None, order=None, moisture_content=0.79):
+                 split=None, order=None, moisture_content=None):
         self._load_thermo(thermo)
+        chemicals = self.chemicals
+        ID_water = chemicals['7732-18-5'].ID # Water must be defined
         if split is None:
-            chemicals = self.chemicals
             split = dict(
                 Furfural=1,
                 Glycerol=0.8889,
@@ -398,6 +399,10 @@ class SludgeCentrifuge(SolidsSeparator):
             )
             remove_undefined_chemicals(split, chemicals)
             default_chemical_dict(split, chemicals, 0.9394, 0.9286, 0.04991)
+            split.pop(ID_water) # Remove water from split
+        if ID_water not in split and moisture_content is None:
+            # Only set moisture content if water split is not given
+            moisture_content = 0.79
         SolidsSeparator.__init__(
             self, ID, ins, outs, thermo, split=split, order=order,
             moisture_content=moisture_content, 

--- a/biosteam/units/wastewater.py
+++ b/biosteam/units/wastewater.py
@@ -317,7 +317,6 @@ class AerobicDigestion(Unit):
         water.mol[:] -= vent.mol
         
 
-# TODO: Use moisture content
 class SludgeCentrifuge(SolidsSeparator):
     """
     Create a centrifuge to separate sludge. The model is based on 
@@ -336,11 +335,14 @@ class SludgeCentrifuge(SolidsSeparator):
         * [dict] ID-split pairs of feed to 0th outlet stream
     order=None : Iterable[str], defaults to biosteam.settings.chemicals.IDs
         Chemical order of split.
+    moisture_content : float, optional
+        Moisture content of sludge. Defaults to 0.79 based on stream 623 in [1]_
+        (or 20% for insolubles).
     
     """
     purchase_cost = installation_cost = 0
     def __init__(self, ID='', ins=None, outs=(), thermo=None, *, 
-                 split=None, order=None, moisture_content=0.46):
+                 split=None, order=None, moisture_content=0.79):
         self._load_thermo(thermo)
         if split is None:
             chemicals = self.chemicals


### PR DESCRIPTION
Hi @yoelcortes, I just updated the moisture content after the sludge this bioindustrial-park issue (plus some typo fixes):
https://github.com/BioSTEAMDevelopmentGroup/Bioindustrial-Park/issues/46

It didn't really change the MESP for the cornstover biorefinery (haven't checked other biorefineries, and I'm using the biorefineries@wwt so slightly outdated):
```python
MESP: $2.14/gal
Stream: sludge from <SludgeCentrifuge: S603> to <Mixer: slurry_mixer>
 phase: 'l', T: 307.75 K, P: 101325 Pa
 composition (%): Water              79
                  Ethanol            2.05e-05
                  AceticAcid         0.0104
                  Glycerol           0.00188
                  LacticAcid         0.0102
                  SuccinicAcid       0.00468
                  DAP                0.0393
                  AmmoniumSulfate    0.693
                  SO2                0.000233
                  Arabinose          0.0132
                  Extract            0.0763
                  Ash                1
                  NaOH               0.487
                  Lignin             2.95
                  SolubleLignin      0.0041
                  GlucoseOligomer    0.0122
                  GalactoseOligomer  3.08e-05
                  MannoseOligomer    1.62e-05
                  XyloseOligomer     0.0043
                  ArabinoseOligomer  0.000524
                  Z_mobilis          0.0159
                  Protein            0.0561
                  Glucan             0.00941
                  Xylan              0.00882
                  Xylitol            0.00848
                  Cellobiose         0.00222
                  Arabinan           0.00402
                  Mannan             0.0142
                  Galactan           0.00331
                  WWTsludge          15.6
                  Cellulase          0.00392
                  -----------------  6.58e+03 kg/hr
```

One thing I do wonder, is about this warning: 
```python
/Users/yalinli_cabbi/Coding/bst/biosteam/units/wastewater.py:401: RuntimeWarning: cannot define both moisture split and moisture content
```

My first intuition is to add `if moisture_content: chemicals = [i for i in chemicals if i is not chemicals.H2O]` after this line:
https://github.com/BioSTEAMDevelopmentGroup/biosteam/blob/d8d89f290d9be5a7ccd9ea531cd9fc0df6e49041/biosteam/units/wastewater.py#L346

but it drove MESP way higher, so I'm not exactly sure about it, but it'll be nice to fix the warning, thanks!