### PR TITLE
Move computation of ideal power and duty from run to design

### DIFF
--- a/biosteam/units/compressor.py
+++ b/biosteam/units/compressor.py
@@ -347,7 +347,6 @@ class IsothermalCompressor(Compressor, new_graphics=False):
     def _run(self):
         feed = self.ins[0]
         out = self.outs[0]
-        self.ideal_power, self.ideal_duty = None, None
         out.copy_like(feed)
         out.P = self.P
         out.T = feed.T
@@ -358,7 +357,7 @@ class IsothermalCompressor(Compressor, new_graphics=False):
         super()._design()
         feed = self.ins[0]
         outlet = self.outs[0]
-        ideal_power, ideal_duty = self._calculate_ideal_power_and_duty() if not (self.ideal_power and self.ideal_duty) else self.ideal_power, self.ideal_duty
+        ideal_power, ideal_duty = self._calculate_ideal_power_and_duty()
         Q = ideal_duty / self.eta
         self.add_heat_utility(unit_duty=Q, T_in=feed.T, T_out=outlet.T)
         self.design_results['Ideal power'] = ideal_power # kW


### PR DESCRIPTION
@sarangbhagwat,

I looked at your comment regarding the need to have the computation of ideal power and duty in the "run" instead of "design" method of an isothermal compressor and I am not sure I completely understand it. The design method is run after all unit specifications, so I do not see a need to compute these values during recycle system convergence. Also, if the ideal power or duty is needed during a specification (for any reason), users can use the `_calculate_ideal_power_and_duty` method.

To help me understand your changes better, can you post a working example here where the changes you made in a8955099b22ebfac52281eccadb17b2e92255a4a are needed?

Otherwise, if you believe the past changes are no longer needed, please feel free to approve this pull request.

Thanks!