### PR TITLE
Fix bug with cost decorator

### DIFF
--- a/biosteam/units/decorators/_cost.py
+++ b/biosteam/units/decorators/_cost.py
@@ -64,8 +64,6 @@ class CostItem:
             if not isinstance(N, str): # Prevent downstream error for common mistakes
                 raise ValueError("N parameter must be a string or None; not a "
                                  "'{type(N).__name__}' object")
-        elif ub is not None:
-            N = '#'
         else:
             N = None
         self._basis = str(basis)


### PR DESCRIPTION
Anyone can approve this pull request; it is very minor. This pull fixes a bug with cost decorator when operating with a size factor under the lower bound and adds tests that fail without the fix.

Now the following works: 
```python
from biosteam.units.decorators import cost
bst.settings.set_thermo(['Water'], cache=True)
@cost('Flow rate', CE=bst.settings.CEPCI, cost=1, n=0.6, lb=2, ub=10, units='kg/hr', BM=2.)
class A(bst.Unit): pass

feed = bst.Stream('feed', Water=1, units='kg/hr')

# Test when size factor is under lower bound
A1 = A('A1', ins=feed)
A1.simulate()
assert_allclose(A1.purchase_cost, 2 ** 0.6)
assert_allclose(A1.installed_cost, 2 ** 1.6)
````

Before the bug fix, the following error was raised:
```python
KeyError: '#'
```