### PR TITLE
Enhancements to append_wwt_chemicals

### DIFF
--- a/biosteam/_unit.py
+++ b/biosteam/_unit.py
@@ -756,9 +756,9 @@ class Unit:
                     purchase_costs[name] = purchase_cost
     
     def _assert_compatible_property_package(self):
-        chemicals = self.chemicals
+        CASs = self.chemicals.CASs
         streams = self._ins + self._outs
-        assert all([s.chemicals is chemicals for s in streams if s]), (
+        assert all([s.chemicals.CASs == CASs for s in streams if s]), (
             "unit operation chemicals are incompatible with inlet and outlet streams; "
             "try using the `thermo` keyword argument to initialize the unit operation "
             "with a compatible thermodynamic property package"

--- a/biosteam/units/solids_separation.py
+++ b/biosteam/units/solids_separation.py
@@ -96,7 +96,7 @@ class SolidsSeparator(Splitter):
 class SolidsCentrifuge(SolidsSeparator):
     """
     Create a solids centrifuge that separates out solids according to
-    user defined split. Capital cost is based on [1]_
+    user defined split. Capital cost is based on [1]_.
     
     Parameters
     ----------
@@ -383,12 +383,13 @@ class PressureFilter(SolidsSeparator):
 PressureFilter._stacklevel += 1
 
 #: TODO: Check BM assumption. Use 1.39 for crushing unit operations for now.
-@cost('Flow rate', units='lb/hr', CE=567, lb=150, ub=12000, kW=0.001, BM=1.39, 
+# Energy consumption - 5 bdmt (tonne dry biomass) https://www.andritz.com/products-en/group/pulp-and-paper/service-solutions/screw-press-service/screw-press-upgrade-case-study-1-less
+@cost('Flow rate', units='lb/hr', CE=567, lb=150, ub=12000, BM=1.39, 
       f=lambda S: exp((11.0991 - 0.3580*log(S) + 0.05853*log(S)**2)))
 class ScrewPress(SolidsSeparator):
     """
     Create screw press unit operation for the 
-    expression of liquids from solids.
+    expression of liquids from solids. Capital cost is based on [1]_.
     
     Parameters
     ----------
@@ -401,5 +402,13 @@ class ScrewPress(SolidsSeparator):
            Component splits.
     moisture_content : float
         Fraction of water in solids.
-                       
-    """
+                  
+    
+    """ 
+    kW_per_bdmt = 5 # Maximally 12
+    
+    def _cost(self):
+        self._decorated_cost()
+        feed = self.ins[0]
+        bdmt = (feed.F_mass - feed.imass['Water']) * 0.001
+        self.add_power_utility(bdmt * self.kW_per_bdmt)

--- a/biosteam/wastewater/high_rate/membrane_bioreactor.py
+++ b/biosteam/wastewater/high_rate/membrane_bioreactor.py
@@ -89,6 +89,10 @@ class AnMBR(bst.Unit):
         the treated water and all of the WWTsludge goes to the wasted sludge.
         Default splits (based on the membrane bioreactor in [2]_) will be used
         if not provided.
+    sludge_conc : float
+        Concentration of biomass in the waste sludge stream, in g/L. 
+        Note that the solids content of the effluent should be smaller than the
+        solids content of the waste sludge stream.
     T : float
         Temperature of the reactor.
         Will not control temperature if provided as None.
@@ -197,6 +201,7 @@ class AnMBR(bst.Unit):
                  Y_biomass=0.05, # from the 0.02-0.08 uniform range in ref [1]
                  biodegradability={},
                  split={},
+                 sludge_conc=10.5,
                  T=35+273.15,
                  include_pump_building_cost=False,
                  include_excavation_cost=False,
@@ -215,6 +220,7 @@ class AnMBR(bst.Unit):
         self.biodegradability = \
             biodegradability if biodegradability else get_BD_dct(self.chemicals)
         self.split = split if split else get_split_dct(self.chemicals)
+        self.sludge_conc = sludge_conc
         self.T = T
         self.include_pump_building_cost = include_pump_building_cost
         self.include_excavation_cost = include_excavation_cost
@@ -346,6 +352,9 @@ class AnMBR(bst.Unit):
             diff = sludge.ivol['Water'] - m_insolubles/sludge_conc
             sludge.ivol['Water'] = m_insolubles/sludge_conc
             perm.ivol['Water'] += diff
+        if perm.imass['Water'] < 0:
+            raise ValueError('Not enough moisture in the influent for waste sludge '
+                             f'with {sludge_conc} g/L sludge concentration.')
 
         degassing(perm, biogas)
         degassing(sludge, biogas)


### PR DESCRIPTION
@yalinli2,

This pull takes care of following issues in `append_wwt_chemicals`:
* Avoid recreating the Chemicals object in `create_high_rate_wastewater_treatment_system` (due to running fthermo) when no new chemicals need to be added.
* Avoid changing chemical property models of chemicals already present in the Chemicals object. 
* Refactor the code that creates the chemicals to `create_missing_wwt_chemicals` to allow user to change any chemical properties before compiling.
* Aliases are already automatically added when compiling Chemicals object (at some point this feature was added to thermosteam, but it went unnoticed), so the code adding aliases was removed.

The pull also makes the following miscellaneous changes:
* `Unit._assert_compatible_property_package` now allows different chemicals objects between streams so long as CASs are the same.

Thanks!