### PR TITLE
Add parameter N_reactors to StirredTankReactor and enable passing RGBn tuples as arguments for color_wheel in plot_spearman_2d

### DIFF
--- a/biosteam/plots/plots.py
+++ b/biosteam/plots/plots.py
@@ -662,8 +662,9 @@ def plot_spearman_2d(rhos, top=None, name=None, color_wheel=None, index=None,
          Spearman's rank correlation coefficients to be plotted.
     top=None : float, optional
         Number of parameters to plot (from highest values).
-    color_wheel=None: list, optional
-        Iterable, either (A) of color objects with attribute 'RGBn' giving tuples of RGBn values, or (B) of tuples of RGBn values.
+    color_wheel=None: Iterable, optional
+        Iterable of colorpalette.Color objects or RGBn values.
+    
     Returns
     -------
     fig : matplotlib Figure
@@ -688,12 +689,10 @@ def plot_spearman_2d(rhos, top=None, name=None, color_wheel=None, index=None,
     if not color_wheel: color_wheel = CABBI_colors.wheel()
     fig, ax = plt.subplots()
     for i, rho in enumerate(rhos):
-        if isinstance(color_wheel[N - i - 1], tuple):
-            plot_spearman_1d(rho, color=color_wheel[N - i - 1], s=s, offset=i,
-                             fig=fig, ax=ax, style=False, sort=False, top=None)
-        else:
-            plot_spearman_1d(rho, color=color_wheel[N - i - 1].RGBn, s=s, offset=i,
-                             fig=fig, ax=ax, style=False, sort=False, top=None)
+        color = color_wheel[N - i - 1]
+        if hasattr(color, 'RGBn'): color = color.RGBn
+        plot_spearman_1d(rho, color=color, s=s, offset=i,
+                         fig=fig, ax=ax, style=False, sort=False, top=None)
     # Plot central line
     yranges = [(s/2 + s*i - 1., 1.) for i in range(len(rhos[0]))]
     format_spearman_plot(ax, index, name, yranges, xlabel)

--- a/biosteam/plots/plots.py
+++ b/biosteam/plots/plots.py
@@ -687,8 +687,12 @@ def plot_spearman_2d(rhos, top=None, name=None, color_wheel=None, index=None,
     if not color_wheel: color_wheel = CABBI_colors.wheel()
     fig, ax = plt.subplots()
     for i, rho in enumerate(rhos):
-        plot_spearman_1d(rho, color=color_wheel[N - i - 1].RGBn, s=s, offset=i,
-                         fig=fig, ax=ax, style=False, sort=False, top=None)
+        if isinstance(color_wheel[N - i - 1], tuple):
+            plot_spearman_1d(rho, color=color_wheel[N - i - 1], s=s, offset=i,
+                             fig=fig, ax=ax, style=False, sort=False, top=None)
+        else:
+            plot_spearman_1d(rho, color=color_wheel[N - i - 1].RGBn, s=s, offset=i,
+                             fig=fig, ax=ax, style=False, sort=False, top=None)
     # Plot central line
     yranges = [(s/2 + s*i - 1., 1.) for i in range(len(rhos[0]))]
     format_spearman_plot(ax, index, name, yranges, xlabel)

--- a/biosteam/plots/plots.py
+++ b/biosteam/plots/plots.py
@@ -662,7 +662,8 @@ def plot_spearman_2d(rhos, top=None, name=None, color_wheel=None, index=None,
          Spearman's rank correlation coefficients to be plotted.
     top=None : float, optional
         Number of parameters to plot (from highest values).
-    
+    color_wheel=None: list, optional
+        Iterable, either (A) of color objects with attribute 'RGBn' giving tuples of RGBn values, or (B) of tuples of RGBn values.
     Returns
     -------
     fig : matplotlib Figure

--- a/biosteam/units/stirred_tank_reactor.py
+++ b/biosteam/units/stirred_tank_reactor.py
@@ -275,6 +275,7 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
         P_psi = P_pascal * 0.000145038 # Pa to psi
         length_to_diameter = self.length_to_diameter
         
+        N = 0
         if self.batch:
             v_0 = ins_F_vol
             tau = self.tau
@@ -297,7 +298,8 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
             else:
                 V_reactor = V_total / N
             Design['Reactor volume'] = V_reactor
-            
+        self.N_reactors = N
+        
         D = cylinder_diameter_from_volume(V_reactor, self.length_to_diameter)
         D *= 3.28084 # Convert from m to ft
         L = D * length_to_diameter

--- a/biosteam/units/stirred_tank_reactor.py
+++ b/biosteam/units/stirred_tank_reactor.py
@@ -65,7 +65,8 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
         Defaults to `continuous`.
     tau_0 : 
         Cleaning and unloading time (if batch mode). Defaults to 3 hr.
-    
+    N_reactors :
+        Number of reactors.
     Notes
     -----
     The recirculation loop takes into account the required flow rate needed to

--- a/biosteam/units/stirred_tank_reactor.py
+++ b/biosteam/units/stirred_tank_reactor.py
@@ -171,6 +171,8 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
     Total purchase cost                                          USD             2.05e+06
     Utility cost                                              USD/hr                  152
     
+    >>> R1.results()
+    4
     '''
     auxiliary_unit_names = (
         'heat_exchanger', 

--- a/biosteam/units/stirred_tank_reactor.py
+++ b/biosteam/units/stirred_tank_reactor.py
@@ -171,8 +171,6 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
     Total purchase cost                                          USD             2.05e+06
     Utility cost                                              USD/hr                  152
     
-    >>> R1.results()
-    4
     '''
     auxiliary_unit_names = (
         'heat_exchanger', 
@@ -277,8 +275,6 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
         P_pascal = (self.P if self.P else self.outs[0].P)
         P_psi = P_pascal * 0.000145038 # Pa to psi
         length_to_diameter = self.length_to_diameter
-        
-        N = 0
         if self.batch:
             v_0 = ins_F_vol
             tau = self.tau
@@ -302,7 +298,6 @@ class StirredTankReactor(PressureVessel, Unit, isabstract=True):
                 V_reactor = V_total / N
             Design['Reactor volume'] = V_reactor
         self.N_reactors = N
-        
         D = cylinder_diameter_from_volume(V_reactor, self.length_to_diameter)
         D *= 3.28084 # Convert from m to ft
         L = D * length_to_diameter


### PR DESCRIPTION
As the title suggests, these are minor changes enabling the following:
(i) View number of reactors for a `StirredTankReactor` object using a new attribute, `N_reactors`;
(ii) Pass iterable of RGBn tuples rather than iterable of colors for the color_wheel argument in `plot_spearman_2d`.

I have updated the doctest for `StirredTankReactor` to cover (i); if testing is needed for (ii), feel free to add any, thanks!
