### PR TITLE
Allow sorting candidate heat utils by temperature in HeatExchangerNetwork 

### DIFF
--- a/biosteam/facilities/hxn/_heat_exchanger_network.py
+++ b/biosteam/facilities/hxn/_heat_exchanger_network.py
@@ -108,7 +108,8 @@ class HeatExchangerNetwork(bst.Facility):
     
     def __init__(self, ID='', T_min_app=5., units=None, ignored=None, Qmin=1e-3,
                  force_ideal_thermo=False, cache_network=False, avoid_recycle=False,
-                 acceptable_energy_balance_error=None, replace_unit_heat_utilities=False):
+                 acceptable_energy_balance_error=None, replace_unit_heat_utilities=False,
+                 sort_hus_by_T=False):
         bst.Facility.__init__(self, ID, None, None)
         self.T_min_app = T_min_app
         self.units = units
@@ -118,6 +119,7 @@ class HeatExchangerNetwork(bst.Facility):
         self.cache_network = cache_network
         self.avoid_recycle = avoid_recycle
         self.replace_unit_heat_utilities = replace_unit_heat_utilities
+        self.sort_hus_by_T = sort_hus_by_T
         if acceptable_energy_balance_error is not None:
             self.acceptable_energy_balance_error = acceptable_energy_balance_error
         
@@ -189,7 +191,8 @@ class HeatExchangerNetwork(bst.Facility):
                 T_out_arr, pinch_T_arr, C_flow_vector, hx_heat_utils_rearranged, streams_inlet, stream_HXs_dict,\
                 hot_indices, cold_indices = \
                 synthesize_network(hx_utils, self.T_min_app, self.Qmin, 
-                                   self.force_ideal_thermo, self.avoid_recycle)
+                                   self.force_ideal_thermo, self.avoid_recycle,
+                                   self.sort_hus_by_T)
                 new_HXs = HXs_hot_side + HXs_cold_side
                 self.cold_indices = cold_indices
                 self.original_heat_exchangers = hxs

--- a/biosteam/facilities/hxn/_heat_exchanger_network.py
+++ b/biosteam/facilities/hxn/_heat_exchanger_network.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This module will be moved to a new reporsitory called "HXN: The automated Heat Exchanger Network design package."
-# Copyright (C) 2020-2023, Sarang Bhagwat <sarangb2@illinois.edu>, Yoel Cortes-Pena <yoelcortes@gmail.com>
+# Copyright (C) 2020-, Sarang Bhagwat <sarangb2@illinois.edu>, Yoel Cortes-Pena <yoelcortes@gmail.com>
 # 
 # This module is under the UIUC open-source license. See 
 # github.com/BioSTEAMDevelopmentGroup/biosteam/blob/master/LICENSE.txt

--- a/biosteam/facilities/hxn/hxn_synthesis.py
+++ b/biosteam/facilities/hxn/hxn_synthesis.py
@@ -124,10 +124,16 @@ class Working_Life_Cycle:
         return self.life_cycle
     
 
-def temperature_interval_pinch_analysis(hus, T_min_app = 10, force_ideal_thermo=False):
+def temperature_interval_pinch_analysis(hus, 
+                                        T_min_app = 10, 
+                                        force_ideal_thermo=False,
+                                        sort_hus_by_T=False):
     hx_utils = hus
     hus_heating = [hu for hu in hx_utils if hu.duty > 0]
     hus_cooling = [hu for hu in hx_utils if hu.duty < 0]
+    if sort_hus_by_T:
+        hus_heating.sort(key=lambda i: i.unit.ins[0].T, reverse=True)
+        hus_cooling.sort(key=lambda i: i.unit.ins[0].T)
     hx_utils_rearranged = hus_heating + hus_cooling
     hxs = [hu.unit for hu in hx_utils_rearranged]
     if force_ideal_thermo:
@@ -249,10 +255,11 @@ def get_T_transient(pinch_T_arr, indices, T_in_arr):
     return T_transient
 
 def synthesize_network(hus, T_min_app=5., Qmin=1e-3, force_ideal_thermo=False,
-                       avoid_recycle=False):  
+                       avoid_recycle=False, sort_hus_by_T=False):  
     pinch_T_arr, hot_util_load, cold_util_load, T_in_arr, T_out_arr,\
         hxs, hot_indices, cold_indices, indices, streams_inlet, hx_utils_rearranged, \
-        streams_quenched = temperature_interval_pinch_analysis(hus, T_min_app, force_ideal_thermo)        
+        streams_quenched = temperature_interval_pinch_analysis(hus, T_min_app, force_ideal_thermo,
+                                                               sort_hus_by_T)        
     H_out_arr = [i.H for i in streams_quenched]
     duties = np.array([abs(hx.Q)  for hx in hxs])
     dTs = np.abs(T_in_arr - T_out_arr)

--- a/biosteam/facilities/hxn/hxn_synthesis.py
+++ b/biosteam/facilities/hxn/hxn_synthesis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # HXN: The automated Heat Exchanger Network design package.
-# Copyright (C) 2020-2023, Sarang Bhagwat <sarangb2@illinois.edu>
+# Copyright (C) 2020-, Sarang Bhagwat <sarangb2@illinois.edu>
 # 
 # This module is under the UIUC open-source license. See 
 # github.com/sarangbhagwat/hxn/blob/master/LICENSE.txt

--- a/biosteam/facilities/hxn/hxn_synthesis.py
+++ b/biosteam/facilities/hxn/hxn_synthesis.py
@@ -125,7 +125,7 @@ class Working_Life_Cycle:
     
 
 def temperature_interval_pinch_analysis(hus, 
-                                        T_min_app = 10, 
+                                        T_min_app=10, 
                                         force_ideal_thermo=False,
                                         sort_hus_by_T=False):
     hx_utils = hus


### PR DESCRIPTION
I've added an optional argument sort_hus_by_T to HeatExchangerNetwork initialization. This allows sorting hus_heating (by descending T) and hus_cooling (by ascending T) while synthesizing networks. While not a requisite in pinch-based HXN synthesis, this can sometimes enable better matches in the absence of stream splitting. 