### PR TITLE
Fix Typo: Correct "specificiation" to "specification" in Unit Descriptions

### DIFF
--- a/biosteam/process_tools/utils.py
+++ b/biosteam/process_tools/utils.py
@@ -132,7 +132,7 @@ def rename_unit(unit, area):
     * U = Other units
     * V = Valve
     * J = Junction, not a physical unit (serves to adjust streams)
-    * PS = Process specificiation, not a physical unit (serves to adjust streams)
+    * PS = Process specification, not a physical unit (serves to adjust streams)
     
     Examples
     --------
@@ -182,7 +182,7 @@ def rename_units(units, area):
     * T = Tank or bin for storage
     * U = Other units
     * J = Junction, not a physical unit (serves to adjust streams)
-    * PS = Process specificiation, not a physical unit (serves to adjust streams)
+    * PS = Process specification, not a physical unit (serves to adjust streams)
     
     Examples
     --------


### PR DESCRIPTION


Description:  
This pull request fixes a typo in the unit descriptions within the biosteam/process_tools/utils.py file. The word "specificiation" has been corrected to "specification" in two locations. This change improves the clarity and professionalism of the documentation for process units. No functional code was modified.