### PR TITLE
fix: list element replacement

### DIFF
--- a/biosteam/process_tools/segment.py
+++ b/biosteam/process_tools/segment.py
@@ -29,7 +29,8 @@ class Segment:
         self.sink.ins[self.sink_index] = None
             
     def insert(self, stream):
-        stream.sink.ins.replace(stream, self.source.outs[self.source_index])
+        i = stream.sink.ins.index(stream)
+        stream.sink.ins[i] = self.source.outs[self.source_index]
         self.sink.ins[self.sink_index] = stream
         
         


### PR DESCRIPTION
`list.replace()` doesn’t exist in Python, so it was crashing. switched to replacing the item by index instead:

```python
i = stream.sink.ins.index(stream)
stream.sink.ins[i] = self.source.outs[self.source_index]
```

now it runs without errors.