### PR TITLE
Fix System.save_report for pandas 3.0 (and another two bugs)

### DIFF
--- a/biosteam/_system.py
+++ b/biosteam/_system.py
@@ -4378,6 +4378,7 @@ class System:
         writer = pd.ExcelWriter(file)
         units = sorted(self.units, key=lambda x: x.line)
         cost_units = [i for i in units if i._design or i._cost]
+        diagram_completed = False
         if 'Flowsheet' in sheets:
             try:
                 with bst.preferences.temporary() as p:
@@ -4414,8 +4415,8 @@ class System:
             if tea:
                 tea = self.TEA
                 cost = report.cost_table(tea)
-                cost.to_excel(writer, 'Itemized costs')
-                tea.get_cashflow_table().to_excel(writer, 'Cash flow')
+                cost.to_excel(writer, sheet_name='Itemized costs')
+                tea.get_cashflow_table().to_excel(writer, sheet_name='Cash flow')
             else:
                 warn(f'Cannot find TEA object in {repr(self)}. Ignoring TEA sheets.',
                      RuntimeWarning, stacklevel=2)
@@ -4469,11 +4470,18 @@ class System:
             )
         
         if 'Water mass balance' in sheets:
-            water_mass_balance = report.water_mass_balance_table(self)
-            report.tables_to_excel(
-                [water_mass_balance], writer, 
-                'Water mass balance'
-            )
+            try:
+                water_mass_balance = report.water_mass_balance_table(self)
+            except LookupError:
+                # The water mass balance is defined relative to a ProcessWaterCenter;
+                # skip the sheet when the system does not have one.
+                warn('Cannot find a ProcessWaterCenter; skipping the water mass '
+                     'balance sheet.', RuntimeWarning, stacklevel=2)
+            else:
+                report.tables_to_excel(
+                    [water_mass_balance], writer,
+                    'Water mass balance'
+                )
         
         if 'CAPEX' in sheets:
             CAPEX = tea.CAPEX_table()

--- a/biosteam/report/table.py
+++ b/biosteam/report/table.py
@@ -596,7 +596,7 @@ def tables_to_excel(tables, writer, sheet='Sheet1', n_row=1, row_spacing=2):
     row_spacing += 1 # Account for Python index offset
     for t in tables:
         label = t.columns.name
-        t.to_excel(writer, sheet, 
+        t.to_excel(writer, sheet_name=sheet,
                    startrow=n_row, index_label=label)
         n_row += len(t.index) + row_spacing
     return n_row

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -87,9 +87,33 @@ def test_stream_table(system):
     assert list(df) == IDs
     assert list(df.index) == index
 
-# TODO: Figure out problem Workbook bug with xlsx writter that appears in CI
-# def test_save_report(system, tea):
-#     assert system.TEA is tea
-#     system.save_report("report.xlsx") # Make sure it runs
-#     os.remove("report.xlsx")
-#     # TODO: More robust test for this method
+def test_save_report(system, tea, tmp_path):
+    # Scoped sheets (no 'Flowsheet', so no graphviz needed) exercise the
+    # `to_excel(..., sheet_name=...)` path that newer pandas requires, and the
+    # `diagram_completed` initialization for when 'Flowsheet' is omitted.
+    import openpyxl
+    assert system.TEA is tea
+    path = tmp_path / 'report.xlsx'
+    system.save_report(str(path), sheets={'Itemized costs', 'Stream table',
+                                          'Design requirements', 'Utilities'})
+    wb = openpyxl.load_workbook(path, read_only=True)
+    try:
+        sheets = set(wb.sheetnames)
+    finally:
+        wb.close()
+    assert {'Itemized costs', 'Cash flow', 'Stream table',
+            'Design requirements'} <= sheets
+
+def test_save_report_skips_water_mass_balance_without_PWC(system, tea, tmp_path):
+    # The water mass balance is defined relative to a ProcessWaterCenter; without
+    # one, the sheet is skipped (with a warning) instead of raising.
+    import openpyxl
+    path = tmp_path / 'report.xlsx'
+    system.save_report(str(path), sheets={'Water mass balance', 'Stream table'})
+    wb = openpyxl.load_workbook(path, read_only=True)
+    try:
+        sheets = set(wb.sheetnames)
+    finally:
+        wb.close()
+    assert 'Stream table' in sheets
+    assert 'Water mass balance' not in sheets


### PR DESCRIPTION
pandas 3.0 made DataFrame/Series.to_excel's `sheet_name` keyword-only, so the positional calls in save_report raised
`TypeError: NDFrame.to_excel() takes 2 positional arguments but 3 were given`. Pass `sheet_name=` instead (Itemized costs, Cash flow, and report.tables_to_excel, which the other sheets route through). This is backward compatible: `sheet_name` has always been a valid keyword on pandas 2.x.

Also fixes two pre-existing, pandas-independent save_report bugs surfaced while testing:
- Initialize `diagram_completed = False` so a custom `sheets` set that omits 'Flowsheet' no longer raises UnboundLocalError at cleanup.
- Skip the 'Water mass balance' sheet (with a warning) when the system has no ProcessWaterCenter, instead of raising LookupError (the sheet is defined relative to a ProcessWaterCenter).

Enable test_save_report and add test_save_report_skips_water_mass_balance_without_PWC in tests/test_report.py (graphviz-free, so CI-safe).