### PR TITLE
Fix replacement cost timing and refactor cashflow calculations

### DIFF
--- a/tests/test_tea.py
+++ b/tests/test_tea.py
@@ -11,6 +11,7 @@
 import pytest, numpy as np, biosteam as bst
 from numpy.testing import assert_allclose
 from biosteam import TEA, System, Stream, Unit, Chemical, settings
+from biosteam._tea import add_replacement_cost_to_cashflow_array
 from biorefineries.tea import create_cellulosic_ethanol_tea
 
 def test_depreciation_schedule():    
@@ -336,9 +337,26 @@ def test_tea():
             table['Loan principal [MM$]'].iloc[0])
     assert_allclose(total_interest_payment1, total_interest_payment2, atol=1e-4)
 
+def test_add_replacement_cost():
+    cashflow_array = np.zeros(12)
+
+    add_replacement_cost_to_cashflow_array(
+        equipment_installed_cost = 100.0,
+        equipment_lifetime = 4,
+        cashflow_array = cashflow_array,
+        venture_years = 10,
+        start = 2
+    )
+
+    expected = np.zeros(12)
+    expected[6] = 100.0
+    expected[10] = 100.0
+
+    assert_allclose(cashflow_array, expected)
 
 if __name__ == '__main__':
     test_depreciation_schedule()
     test_cashflow_consistency()
     test_tea()
     test_tea_startup_months()
+    test_add_replacement_cost()


### PR DESCRIPTION
This pull request fixes the timing of equipment replacement costs in the cashflow array and refactors repeated cashflow calculation logic to improve maintainability.

# Fix replacement cost timing

Fixed `add_replacement_cost_to_cashflow_array`, which was skipping the first equipment replacement. The replacement index was being incremented before the replacement cost was added to the cashflow matrix, causing the first replacement to be delayed by one lifetime period.

For example, equipment with a 4-year lifetime in a 12-year venture starting at year 2 should be replaced first at year `2 + 4`, but the previous implementation placed the first replacement at `(2 + 4) + 4`.

# Refactor cashflow calculations

Removed duplicated cashflow calculation logic from `_taxable_nontaxable_depreciation_cashflows`, `get_cashflows_table`, and `taxable_nontaxable_cashflows` by consolidating the shared logic into a common implementation.

# Inflation-aware TEA calculations

I have also implemented inflation handling in my own TEA version. If this functionality would be useful, I would be happy to discuss how it could be integrated into the TEA framework.