### PR TITLE
Inflation implementation in TEA object

### DIFF
--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -347,7 +347,7 @@ class TEA:
                  '_duration', '_depreciation_key', '_depreciation',
                  '_years', '_duration', '_start',  'IRR', '_IRR', '_sales',
                  '_duration_array_cache', 'accumulate_interest_during_construction', 
-                 '_inflation_rate', '_f_inflation')
+                 '_inflation_rate', '_inflation_factors')
     
     #: Available depreciation schedules. Defaults include modified 
     #: accelerated cost recovery system from U.S. IRS publication 946 (MACRS),
@@ -461,16 +461,23 @@ class TEA:
                 startup_salesfrac: float, WC_over_FCI: float,  finance_interest: float,
                 finance_years: int, finance_fraction: float,
                 accumulate_interest_during_construction: bool=False,
-                inflation_rate: float|NDArray[float] = None):
+                inflation_rate: float|None = None):
         #: System being evaluated.
         self.system: System = system
         
+        # Inflation
+        self._inflation_rate = None
+        self._inflation_factors = None
+
+        # Time periods 
         self.duration = duration
         self.depreciation = depreciation
         self.construction_schedule = construction_schedule
         self.startup_months = startup_months
         self.operating_days = operating_days
         
+        self.update_inflation_factors()
+
         #: Internal rate of return (fraction).
         self.IRR: float = IRR
         
@@ -508,11 +515,6 @@ class TEA:
         
         #: Whether to immediately pay interest before operation or to accumulate interest during construction
         self.accumulate_interest_during_construction = accumulate_interest_during_construction
-        
-        # Inflation
-        self._inflation_rate = None
-        self._f_inflation = None
-        self.inflation_rate = inflation_rate
 
         #: For convenience, set a TEA attribute for the system
         system._TEA = self
@@ -587,7 +589,7 @@ class TEA:
         start, end = [int(i) for i in duration]
         self._duration = (start, end)
         self._years = end - start
-        self._f_inflation = self._build_f_inflation()
+        self.update_inflation_factors()
 
     @property
     def depreciation(self) -> str|NDArray[float]:
@@ -665,7 +667,7 @@ class TEA:
     def construction_schedule(self, schedule):
         self._construction_schedule = np.array(schedule, dtype=float)
         self._start = len(schedule)
-        self._f_inflation = self._build_f_inflation()
+        self.update_inflation_factors()
     
     @property
     def startup_months(self) -> float:
@@ -752,18 +754,24 @@ class TEA:
 
     @property
     def inflation_rate(self):
+        """Inflation rate to escalate cashflows to nominal dollars"""
         return self._inflation_rate
     
     @inflation_rate.setter
     def inflation_rate(self, value):
         self._inflation_rate = value
-        self._f_inflation = self._build_f_inflation()
+        self.update_inflation_factors()
 
     @property
-    def f_inflation(self):
-        return self._f_inflation
+    def inflation_factors(self):
+        """Multiplicative factors to scalate cashflows"""
+        return self._inflation_factors
 
-    def _build_f_inflation(self):
+    def update_inflation_factors(self):
+        """Update inflation factors"""
+        self._inflation_factors = self._build_inflation_factors()
+        
+    def _build_inflation_factors(self):
         """Nominal inflation factors aligned with TEA cashflow arrays"""
         length = self._start + self._years
         inflation = self.inflation_rate
@@ -773,22 +781,14 @@ class TEA:
         
         if isinstance(inflation, (int, float)):
             return build_nominal_factors(np.ones(length, dtype=float), inflation)
-        
-        if isinstance(inflation, np.ndarray):
-            factors = inflation
 
-            if factors.ndim != 1:
-                raise ValueError("inflation factors must be a 1D array.")
-            
-            if factors.size != length:
-                raise ValueError(f"inflation factors must have length {length}; got {factors.size}.")
-            
-            if not np.isclose(factors[0], 1.0):
-                raise ValueError("inflation factor at index 0 must be 1.0.")
-            
-            return factors
-
-        raise TypeError("inflation_rate must be None, float annual rate or 1D numpy array of nominal factors.")
+        raise TypeError("inflation_rate must be None or float annual rate.")
+    
+    def _get_discount_rate(self):
+        """Return nominal IRR when inflation is active, otherwise real IRR"""
+        if self.inflation_rate is None:
+            return self.IRR
+        return (1.0 + self.IRR) * (1.0 + self.inflation_rate) - 1.0
 
     def _get_duration_array(self):
         key = start, years = (self._start, self._years)
@@ -844,7 +844,7 @@ class TEA:
         FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
-        f_inflation = self.f_inflation
+        f_inflation = self.inflation_factors
         FOC = self._FOC(FCI)
         VOC = self.VOC
         sales = self.sales
@@ -916,7 +916,7 @@ class TEA:
         )
         NE[:] = taxable_cashflow + I - T
         CF[:] = NE + nontaxable_cashflow
-        DF[:] = 1/(1.+self.IRR)**self._get_duration_array()
+        DF[:] = 1/(1.+self._get_discount_rate())**self._get_duration_array()
         NPV[:] = CF * DF
         CNPV[:] = NPV.cumsum()
         DF *= 1e6
@@ -936,7 +936,7 @@ class TEA:
             nontaxable_cashflow, tax, depreciation
         )
         cashflow = nontaxable_cashflow + taxable_cashflow + incentives - tax
-        return NPV_at_IRR(self.IRR, cashflow, self._get_duration_array())
+        return NPV_at_IRR(self._get_discount_rate(), cashflow, self._get_duration_array())
     
     def _AOC(self, FCI):
         """Return AOC at given FCI"""
@@ -958,7 +958,7 @@ class TEA:
         FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
-        inflation_factors = self.f_inflation
+        inflation_factors = self.inflation_factors
         TDC_nom = (TDC0 * self.construction_schedule * inflation_factors[:start]).sum()
         FOC = self._FOC(FCI)
         VOC = self.VOC
@@ -1144,7 +1144,7 @@ class TEA:
         point (NPV = 0) through cash flow analysis. 
         
         """
-        discount_factors = (1 + self.IRR)**self._get_duration_array()
+        discount_factors = (1 + self._get_discount_rate())**self._get_duration_array()
         sales_coefficients = np.ones_like(discount_factors, dtype=float)
         start = self._start
         sales_coefficients[:start] = 0
@@ -1152,7 +1152,7 @@ class TEA:
         end_start = start + int(self._startup_time)
         sales_coefficients[end_start] = w0 * self.startup_salesfrac + (1. - w0) 
         sales_coefficients[start:end_start] = self.startup_salesfrac
-        sales_coefficients *= self.f_inflation
+        sales_coefficients *= self.inflation_factors
         taxable_cashflow, nontaxable_cashflow, depreciation = self._taxable_nontaxable_depreciation_cashflows()
         if np.isnan(taxable_cashflow).any():
             warn('nan encountered in cashflow array; resimulating system', category=RuntimeWarning)

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -587,6 +587,7 @@ class TEA:
         start, end = [int(i) for i in duration]
         self._duration = (start, end)
         self._years = end - start
+        self._f_inflation = self._build_f_inflation()
 
     @property
     def depreciation(self) -> str|NDArray[float]:
@@ -664,6 +665,7 @@ class TEA:
     def construction_schedule(self, schedule):
         self._construction_schedule = np.array(schedule, dtype=float)
         self._start = len(schedule)
+        self._f_inflation = self._build_f_inflation()
     
     @property
     def startup_months(self) -> float:

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -182,6 +182,7 @@ def taxable_and_nontaxable_cashflows(
         start, years,
         lang_factor,
         accumulate_interest_during_construction,
+        f_inflation,
     ):
     # Cash flow data and parameters
     # C_FC: Fixed capital
@@ -202,6 +203,13 @@ def taxable_and_nontaxable_cashflows(
     )
     for i in unit_capital_costs:
         add_all_replacement_costs_to_cashflow_array(i, C_FC, years, start, lang_factor)
+    
+    # Multiply for inflation factors, if inflation None the factors are 1.
+    C *= f_inflation
+    S *= f_inflation
+    C_FC *= f_inflation
+    C_WC *= f_inflation
+
     if finance_interest:
         interest = finance_interest
         years = finance_years
@@ -220,14 +228,9 @@ def taxable_and_nontaxable_cashflows(
         nontaxable_cashflow = D - C_FC - C_WC
     return taxable_cashflow, nontaxable_cashflow
 
-def build_nominal_factors_operating(factors, start, years, rate):
-    operating_index = np.arange(years)
-    factors[start:] = (1.0 + rate)**operating_index
-    return factors
-
-def build_nominal_factors_construction(factors, start, rate):
-    construction_index = np.arange(start, 0, -1)
-    factors[:start] = (1.0 + rate)**(-construction_index)
+def build_nominal_factors(factors, rate):
+    operating_index = np.arange(factors.size)
+    factors[:] = (1.0 + rate)**operating_index
     return factors
 
 def NPV_with_sales(
@@ -343,7 +346,8 @@ class TEA:
                  '_startup_schedule', '_operating_days',
                  '_duration', '_depreciation_key', '_depreciation',
                  '_years', '_duration', '_start',  'IRR', '_IRR', '_sales',
-                 '_duration_array_cache', 'accumulate_interest_during_construction')
+                 '_duration_array_cache', 'accumulate_interest_during_construction', 
+                 '_inflation_rate', '_f_inflation')
     
     #: Available depreciation schedules. Defaults include modified 
     #: accelerated cost recovery system from U.S. IRS publication 946 (MACRS),
@@ -456,7 +460,8 @@ class TEA:
                 startup_months: float, startup_FOCfrac: float, startup_VOCfrac: float,
                 startup_salesfrac: float, WC_over_FCI: float,  finance_interest: float,
                 finance_years: int, finance_fraction: float,
-                accumulate_interest_during_construction: bool=False):
+                accumulate_interest_during_construction: bool=False,
+                inflation_rate: float|NDArray[float] = None):
         #: System being evaluated.
         self.system: System = system
         
@@ -504,6 +509,11 @@ class TEA:
         #: Whether to immediately pay interest before operation or to accumulate interest during construction
         self.accumulate_interest_during_construction = accumulate_interest_during_construction
         
+        # Inflation
+        self._inflation_rate = None
+        self._f_inflation = None
+        self.inflation_rate = inflation_rate
+
         #: For convenience, set a TEA attribute for the system
         system._TEA = self
 
@@ -738,6 +748,46 @@ class TEA:
         net_earnings = self.net_earnings
         return FCI/net_earnings
 
+    @property
+    def inflation_rate(self):
+        return self._inflation_rate
+    
+    @inflation_rate.setter
+    def inflation_rate(self, value):
+        self._inflation_rate = value
+        self._f_inflation = self._build_f_inflation()
+
+    @property
+    def f_inflation(self):
+        return self._f_inflation
+
+    def _build_f_inflation(self):
+        """Nominal inflation factors aligned with TEA cashflow arrays"""
+        length = self._start + self._years
+        inflation = self.inflation_rate
+
+        if inflation is None:
+            return np.ones(length, dtype=float)
+        
+        if isinstance(inflation, (int, float)):
+            return build_nominal_factors(np.ones(length, dtype=float), inflation)
+        
+        if isinstance(inflation, np.ndarray):
+            factors = inflation
+
+            if factors.ndim != 1:
+                raise ValueError("inflation factors must be a 1D array.")
+            
+            if factors.size != length:
+                raise ValueError(f"inflation factors must have length {length}; got {factors.size}.")
+            
+            if not np.isclose(factors[0], 1.0):
+                raise ValueError("inflation factor at index 0 must be 1.0.")
+            
+            return factors
+
+        raise TypeError("inflation_rate must be None, float annual rate or 1D numpy array of nominal factors.")
+
     def _get_duration_array(self):
         key = start, years = (self._start, self._years)
         if key in _duration_array_cache:
@@ -896,21 +946,23 @@ class TEA:
         # S: Sales
         # NE: Net earnings
         # CF: Cash flow
-        TDC = self.TDC
-        FCI = self._FCI(TDC)
+        TDC0 = self.TDC
+        FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
+        inflation_factors = self.f_inflation
+        TDC_nom = (TDC0 * self.construction_schedule * inflation_factors[:start]).sum()
         FOC = self._FOC(FCI)
         VOC = self.VOC
         D, C_FC, C_WC, Loan, LP, C, S = np.zeros((7, start + years))
-        self._fill_depreciation_array(D, start, years, TDC)
+        self._fill_depreciation_array(D, start, years, TDC_nom)
         WC = self.WC_over_FCI * FCI
         system = self.system
         return (
             *taxable_and_nontaxable_cashflows(
                 system.unit_capital_costs if isinstance(system, bst.AgileSystem) else system.cost_units,
                 D, C, S, C_FC, C_WC, Loan, LP,
-                FCI, WC, TDC, VOC, FOC, self.sales,
+                FCI, WC, TDC0, VOC, FOC, self.sales,
                 self._startup_time,
                 self.startup_VOCfrac,
                 self.startup_FOCfrac,
@@ -922,6 +974,7 @@ class TEA:
                 start, years,
                 self.lang_factor,
                 self.accumulate_interest_during_construction,
+                inflation_factors,
             ),
             D
         )

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -762,7 +762,7 @@ class TEA:
 
     @property
     def discount_rate(self):
-        """Return the discount rate based on the real IRR and the inflation rate."""
+        """Return the nominal discount rate based on the real IRR and the inflation rate."""
         return IRR_nominal(self.IRR, self.inflation_rate)
 
     def _get_duration_array(self):

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -287,7 +287,10 @@ class TEA:
     system : 
         Should contain feed and product streams.
     IRR : 
-        Internal rate of return (fraction).
+        Real internal rate of return (fraction). If `inflation_rate` is given,
+        cashflows are escalated to nominal values and this real IRR is internally
+        converted to a nominal dicount rate for NPV calculations. This is done by
+        using Fisher equation: nom_IRR = (1 + IRR)*(1 + inflation_rate) - 1. 
     duration : 
         Start and end year of venture (e.g. (2018, 2038)).
     depreciation : 
@@ -324,6 +327,14 @@ class TEA:
         Number of years the loan is paid for.
     finance_fraction :
         Fraction of capital cost that needs to be financed.
+    inflation_rate :
+        Annual constant inflation rate as a fraction. If provided,
+        operating costs, sales, capital expenses, replacement costs
+        and working capital flows are escalated to nominal dollars
+        using this rate. NPV calculations then use a nominal
+        discount rate computed from `IRR` and `inflation_rate`.
+        If `None`, no inflation is applied and cashflows are treated
+        as base-year dollars.
     
     Warning
     -------
@@ -466,7 +477,7 @@ class TEA:
         self.system: System = system
         
         # Inflation
-        self._inflation_rate = None
+        self._inflation_rate = inflation_rate
         self._inflation_factors = None
 
         # Time periods 
@@ -754,7 +765,7 @@ class TEA:
 
     @property
     def inflation_rate(self):
-        """Inflation rate to escalate cashflows to nominal dollars"""
+        """Annual constant inflation rate used to escalate cashflows to nominal dollars"""
         return self._inflation_rate
     
     @inflation_rate.setter
@@ -764,15 +775,22 @@ class TEA:
 
     @property
     def inflation_factors(self):
-        """Multiplicative factors to scalate cashflows"""
+        """Multiplicative nominal escalation factors aligned with the cashflow array"""
         return self._inflation_factors
 
     def update_inflation_factors(self):
         """Update inflation factors"""
-        self._inflation_factors = self._build_inflation_factors()
+        if hasattr(self,"_start") and hasattr(self, "_years"):
+            self._inflation_factors = self._build_inflation_factors()
         
     def _build_inflation_factors(self):
-        """Nominal inflation factors aligned with TEA cashflow arrays"""
+        """
+        Build nominal escalation factors for all construction and operating years.
+
+        Returns an array of length `self._start + self._years`. If `inflation_rate`
+        is None, all factors are 1. Otherwise, factors are compounded as: 
+        factor[t] = (1 + inflation_rate)**t
+        """
         length = self._start + self._years
         inflation = self.inflation_rate
 
@@ -785,7 +803,7 @@ class TEA:
         raise TypeError("inflation_rate must be None or float annual rate.")
     
     def _get_discount_rate(self):
-        """Return nominal IRR when inflation is active, otherwise real IRR"""
+        """Return the discount rate consistent with the cashflow basis."""
         if self.inflation_rate is None:
             return self.IRR
         return (1.0 + self.IRR) * (1.0 + self.inflation_rate) - 1.0
@@ -818,7 +836,17 @@ class TEA:
         D[start:start + N_depreciation_years] = TDC * depreciation_array
 
     def get_cashflow_table(self):
-        """Return DataFrame of the cash flow analysis."""
+        """
+        Return DataFrame of the cash flow analysis.
+
+        If `inflation_rate` is provided annual, annual costs, sales, capital expenses,
+        replacement costs and working capital are reported in nominal dollars.
+        Discount factors are computed using the nominal discount rate derived from
+        the real `IRR` and `inflation_rate`.
+
+        If `inflation_rate` is None, values are reported in real or base-year dollars and
+        discounted directly with `IRR`.
+        """
         # Cash flow data and parameters
         # index: Year since construction until end of venture
         # C_D: Depreciable capital
@@ -926,7 +954,13 @@ class TEA:
                             columns=cashflow_columns)
     @property
     def NPV(self) -> float:
-        """Net present value."""
+        """
+        Net present value.
+        
+        Uses cashflows consistent with the inflation setting. With inflation, cashflows are
+        nominal and discounted with the internally computed nominal discount rate. without
+        inflation, cashflows are treated as base-year values and discounted with `IRR`.
+        """
         taxable_cashflow, nontaxable_cashflow, depreciation = self._taxable_nontaxable_depreciation_cashflows()
         tax = np.zeros_like(taxable_cashflow)
         incentives = tax.copy()
@@ -1061,8 +1095,23 @@ class TEA:
             return self.AOC - coproduct_sales
     
     def solve_IRR(self, financing=True, bounds=None):
-        """Return the IRR at the break even point (NPV = 0) through cash flow analysis."""
+        """
+        Return the real internal rate of return at the break-even point.
+
+        If `inflation_rate` is provided, this method solves IRR for inflated
+        cashflows and the resulting nominal IRR is converted to real IRR applying
+        Fisher equation: real_IRR = (1 + nominal_IRR)/(1 + inflation_rate) - 1.
+
+        If bounds are provided and `inflation_rate` is not None, bounds must be given
+        as nominal IRR values because the solver operates on nominal cashflows.
+
+        """
         IRR = self._IRR
+
+        # Use nominal IRR as initial guess to solve nominal cashflows
+        if self.inflation_rate is not None:
+            IRR = (1 + IRR)*(1 + self.inflation_rate) - 1
+
         if not IRR or np.isnan(IRR) or IRR < 0.: IRR = 0.01
         if financing:
             args = (self.cashflow_array, self._get_duration_array())
@@ -1093,6 +1142,11 @@ class TEA:
                     )
             finally:
                 self.finance_fraction, self.finance_interest = financing_values
+        
+        # convert nominal IRR to real IRR 
+        if self.inflation_rate is not None:
+            IRR = (1 + IRR)/(1 + self.inflation_rate) - 1
+
         self._IRR = IRR
         return IRR
         
@@ -1141,7 +1195,11 @@ class TEA:
     def solve_sales(self):
         """
         Return the required additional sales [USD] to reach the breakeven 
-        point (NPV = 0) through cash flow analysis. 
+        point (NPV = 0) through cash flow analysis.
+
+        The returned value is expressed in base-year dollars. If `inflation_rate`
+        is provided, this additional sales value is escalated through time using
+        `inflation_factors` before calculating NPV.
         
         """
         discount_factors = (1 + self._get_discount_rate())**self._get_duration_array()

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -289,7 +289,7 @@ class TEA:
     IRR : 
         Real internal rate of return (fraction). If `inflation_rate` is given,
         cashflows are escalated to nominal values and this real IRR is internally
-        converted to a nominal dicount rate for NPV calculations. This is done by
+        converted to a nominal discount rate for NPV calculations. This is done by
         using Fisher equation: nom_IRR = (1 + IRR)*(1 + inflation_rate) - 1. 
     duration : 
         Start and end year of venture (e.g. (2018, 2038)).
@@ -322,7 +322,9 @@ class TEA:
     WC_over_FCI : 
         Working capital as a fraction of fixed capital investment.
     finance_interest : 
-        Yearly interest of capital cost financing as a fraction.
+        Yearly interest of capital cost financing as a fraction. If `inflation_rate`
+        is provided, nominal yearly interest of capiltal cost financing must be 
+        given.
     finance_years : 
         Number of years the loan is paid for.
     finance_fraction :
@@ -1242,7 +1244,7 @@ class TEA:
     
     def _info(self):
         return (f'{type(self).__name__}: {self.system}\n'
-                f'NPV: {self.NPV:,.0f} USD at {self.IRR:.1%} IRR')
+                f'NPV: {self.NPV:,.0f} USD at {self.IRR:.1%} real IRR')
     
     def show(self):
         """Prints information on unit."""

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -838,16 +838,16 @@ class TEA:
         # DF: Discount factor
         # NPV: Net present value
         # CNPV: Cumulative NPV
-        TDC = self.TDC
-        FCI = self._FCI(TDC)
+        TDC0 = self.TDC
+        FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
+        f_inflation = self.f_inflation
         FOC = self._FOC(FCI)
         VOC = self.VOC
         sales = self.sales
         length = start + years
         C_D, C_FC, C_WC, D, L, LI, LP, LPl, C, S, T, I, TE, FL, NE, CF, DF, NPV, CNPV = data = np.zeros((19, length))
-        self._fill_depreciation_array(D, start, years, TDC)
         w0 = self._startup_time % 1
         w1 = 1. - w0
         end_start = start + int(self._startup_time)
@@ -860,15 +860,21 @@ class TEA:
         start1 = end_start + 1
         C[start1:] = VOC + FOC
         S[start1:] = sales
+        C *= f_inflation
+        S *= f_inflation
         WC = self.WC_over_FCI * FCI
-        C_D[:start] = TDC*self._construction_schedule
+        C_D[:start] = TDC0*self._construction_schedule
+        C_D *= f_inflation
+        self._fill_depreciation_array(D, start, years, C_D[:start].sum())
         C_FC[:start] = FCI*self._construction_schedule
         C_WC[start-1] = WC
         C_WC[-1] = -WC
+        C_WC *= f_inflation
         system = self.system
         lang_factor = system.lang_factor
         unit_capital_costs = system.unit_capital_costs.values() if isinstance(system, bst.AgileSystem) else system.cost_units
         for i in unit_capital_costs: add_all_replacement_costs_to_cashflow_array(i, C_FC, years, start, lang_factor)
+        C_FC *= f_inflation
         if self.finance_interest:
             interest = self.finance_interest
             years = self.finance_years

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -1150,6 +1150,7 @@ class TEA:
         end_start = start + int(self._startup_time)
         sales_coefficients[end_start] = w0 * self.startup_salesfrac + (1. - w0) 
         sales_coefficients[start:end_start] = self.startup_salesfrac
+        sales_coefficients *= self.f_inflation
         taxable_cashflow, nontaxable_cashflow, depreciation = self._taxable_nontaxable_depreciation_cashflows()
         if np.isnan(taxable_cashflow).any():
             warn('nan encountered in cashflow array; resimulating system', category=RuntimeWarning)

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -220,6 +220,16 @@ def taxable_and_nontaxable_cashflows(
         nontaxable_cashflow = D - C_FC - C_WC
     return taxable_cashflow, nontaxable_cashflow
 
+def build_nominal_factors_operating(factors, start, years, rate):
+    operating_index = np.arange(years)
+    factors[start:] = (1.0 + rate)**operating_index
+    return factors
+
+def build_nominal_factors_construction(factors, start, rate):
+    construction_index = np.arange(start, 0, -1)
+    factors[:start] = (1.0 + rate)**(-construction_index)
+    return factors
+
 def NPV_with_sales(
         sales, 
         taxable_cashflow, 

--- a/biosteam/_tea.py
+++ b/biosteam/_tea.py
@@ -45,6 +45,16 @@ cashflow_columns = ('Depreciable capital [MM$]',
                     'Net present value (NPV) [MM$]',
                     'Cumulative NPV [MM$]')
 
+# %% Inflation accounting
+
+@njit(cache=True)
+def IRR_nominal(IRR_real, inflation_rate): # By Fisher equation
+    return (1 + IRR_real) * (1 + inflation_rate) - 1
+
+@njit(cache=True)
+def IRR_real(IRR_nominal, inflation_rate): # By Fisher equation
+    return (1 + IRR_nominal) / (1 + inflation_rate) - 1
+
 # %% Depreciation utilities
 
 @njit(cache=True)
@@ -182,7 +192,7 @@ def taxable_and_nontaxable_cashflows(
         start, years,
         lang_factor,
         accumulate_interest_during_construction,
-        f_inflation,
+        inflation_factors,
     ):
     # Cash flow data and parameters
     # C_FC: Fixed capital
@@ -205,10 +215,10 @@ def taxable_and_nontaxable_cashflows(
         add_all_replacement_costs_to_cashflow_array(i, C_FC, years, start, lang_factor)
     
     # Multiply for inflation factors, if inflation None the factors are 1.
-    C *= f_inflation
-    S *= f_inflation
-    C_FC *= f_inflation
-    C_WC *= f_inflation
+    C *= inflation_factors
+    S *= inflation_factors
+    C_FC *= inflation_factors
+    C_WC[start - 1] *= inflation_factors[start - 1]
 
     if finance_interest:
         interest = finance_interest
@@ -227,11 +237,6 @@ def taxable_and_nontaxable_cashflows(
         taxable_cashflow = S - C - D
         nontaxable_cashflow = D - C_FC - C_WC
     return taxable_cashflow, nontaxable_cashflow
-
-def build_nominal_factors(factors, rate):
-    operating_index = np.arange(factors.size)
-    factors[:] = (1.0 + rate)**operating_index
-    return factors
 
 def NPV_with_sales(
         sales, 
@@ -255,8 +260,6 @@ def NPV_with_sales(
     return (cashflow/discount_factors).sum()
 
 # %% Techno-Economic Analysis
-
-_duration_array_cache = {}
 
 class TEA:
     """
@@ -287,10 +290,7 @@ class TEA:
     system : 
         Should contain feed and product streams.
     IRR : 
-        Real internal rate of return (fraction). If `inflation_rate` is given,
-        cashflows are escalated to nominal values and this real IRR is internally
-        converted to a nominal discount rate for NPV calculations. This is done by
-        using Fisher equation: nom_IRR = (1 + IRR)*(1 + inflation_rate) - 1. 
+        Real internal rate of return (fraction).
     duration : 
         Start and end year of venture (e.g. (2018, 2038)).
     depreciation : 
@@ -322,21 +322,21 @@ class TEA:
     WC_over_FCI : 
         Working capital as a fraction of fixed capital investment.
     finance_interest : 
-        Yearly interest of capital cost financing as a fraction. If `inflation_rate`
-        is provided, nominal yearly interest of capiltal cost financing must be 
-        given.
+        Nominal yearly interest of capital cost financing as a fraction.
     finance_years : 
         Number of years the loan is paid for.
     finance_fraction :
         Fraction of capital cost that needs to be financed.
     inflation_rate :
-        Annual constant inflation rate as a fraction. If provided,
-        operating costs, sales, capital expenses, replacement costs
-        and working capital flows are escalated to nominal dollars
-        using this rate. NPV calculations then use a nominal
-        discount rate computed from `IRR` and `inflation_rate`.
-        If `None`, no inflation is applied and cashflows are treated
-        as base-year dollars.
+        Annual constant inflation rate as a fraction. 
+    
+    Notes
+    -----
+    If `inflation_rate` is given, operating costs, sales, capital expenses, 
+    replacement costs and working capital flows are escalated to nominal dollars
+    using this rate. NPV calculations use the nominal discount rate, which is 
+    computed from the real `IRR` and `inflation_rate` by the Fisher equation .
+    If no inflation is applied, cashflows are treated as base-year dollars.
     
     Warning
     -------
@@ -358,9 +358,9 @@ class TEA:
                  'startup_FOCfrac', 'startup_VOCfrac', 'startup_salesfrac',
                  '_startup_schedule', '_operating_days',
                  '_duration', '_depreciation_key', '_depreciation',
-                 '_years', '_duration', '_start',  'IRR', '_IRR', '_sales',
+                 '_years', '_duration', '_start', 'IRR', '_IRR', '_sales',
                  '_duration_array_cache', 'accumulate_interest_during_construction', 
-                 '_inflation_rate', '_inflation_factors')
+                 'inflation_rate')
     
     #: Available depreciation schedules. Defaults include modified 
     #: accelerated cost recovery system from U.S. IRS publication 946 (MACRS),
@@ -473,14 +473,10 @@ class TEA:
                 startup_months: float, startup_FOCfrac: float, startup_VOCfrac: float,
                 startup_salesfrac: float, WC_over_FCI: float,  finance_interest: float,
                 finance_years: int, finance_fraction: float,
-                accumulate_interest_during_construction: bool=False,
-                inflation_rate: float|None = None):
+                accumulate_interest_during_construction: Optional[bool]=None,
+                inflation_rate: Optional[float] = None):
         #: System being evaluated.
         self.system: System = system
-        
-        # Inflation
-        self._inflation_rate = inflation_rate
-        self._inflation_factors = None
 
         # Time periods 
         self.duration = duration
@@ -489,9 +485,10 @@ class TEA:
         self.startup_months = startup_months
         self.operating_days = operating_days
         
-        self.update_inflation_factors()
-
-        #: Internal rate of return (fraction).
+        # Annual constant inflation rate used to escalate cashflows to nominal dollars. Value must be a fraction.
+        self.inflation_rate: float = 0 if inflation_rate is None else float(inflation_rate)
+        
+        #: Real internal rate of return (fraction).
         self.IRR: float = IRR
         
         #: Combined federal and state income tax rate (fraction).
@@ -523,13 +520,13 @@ class TEA:
         #: Guess IRR for solve_IRR method
         self._IRR: float = IRR
         
-        #: Guess cost for solve_price method
+        #: Guess cost for solve_price method.
         self._sales: float = 0
         
-        #: Whether to immediately pay interest before operation or to accumulate interest during construction
-        self.accumulate_interest_during_construction = accumulate_interest_during_construction
+        #: Whether to immediately pay interest before operation or to accumulate interest during construction.
+        self.accumulate_interest_during_construction = False if accumulate_interest_during_construction is None else accumulate_interest_during_construction
 
-        #: For convenience, set a TEA attribute for the system
+        #: For convenience, set a TEA attribute for the system.
         system._TEA = self
 
     def _get_duration(self):
@@ -602,7 +599,6 @@ class TEA:
         start, end = [int(i) for i in duration]
         self._duration = (start, end)
         self._years = end - start
-        self.update_inflation_factors()
 
     @property
     def depreciation(self) -> str|NDArray[float]:
@@ -680,7 +676,6 @@ class TEA:
     def construction_schedule(self, schedule):
         self._construction_schedule = np.array(schedule, dtype=float)
         self._start = len(schedule)
-        self.update_inflation_factors()
     
     @property
     def startup_months(self) -> float:
@@ -766,58 +761,17 @@ class TEA:
         return FCI/net_earnings
 
     @property
-    def inflation_rate(self):
-        """Annual constant inflation rate used to escalate cashflows to nominal dollars"""
-        return self._inflation_rate
-    
-    @inflation_rate.setter
-    def inflation_rate(self, value):
-        self._inflation_rate = value
-        self.update_inflation_factors()
-
-    @property
-    def inflation_factors(self):
-        """Multiplicative nominal escalation factors aligned with the cashflow array"""
-        return self._inflation_factors
-
-    def update_inflation_factors(self):
-        """Update inflation factors"""
-        if hasattr(self,"_start") and hasattr(self, "_years"):
-            self._inflation_factors = self._build_inflation_factors()
-        
-    def _build_inflation_factors(self):
-        """
-        Build nominal escalation factors for all construction and operating years.
-
-        Returns an array of length `self._start + self._years`. If `inflation_rate`
-        is None, all factors are 1. Otherwise, factors are compounded as: 
-        factor[t] = (1 + inflation_rate)**t
-        """
-        length = self._start + self._years
-        inflation = self.inflation_rate
-
-        if inflation is None:
-            return np.ones(length, dtype=float)
-        
-        if isinstance(inflation, (int, float)):
-            return build_nominal_factors(np.ones(length, dtype=float), inflation)
-
-        raise TypeError("inflation_rate must be None or float annual rate.")
-    
-    def _get_discount_rate(self):
-        """Return the discount rate consistent with the cashflow basis."""
-        if self.inflation_rate is None:
-            return self.IRR
-        return (1.0 + self.IRR) * (1.0 + self.inflation_rate) - 1.0
+    def discount_rate(self):
+        """Return the discount rate based on the real IRR and the inflation rate."""
+        return IRR_nominal(self.IRR, self.inflation_rate)
 
     def _get_duration_array(self):
-        key = start, years = (self._start, self._years)
-        if key in _duration_array_cache:
-            duration_array = _duration_array_cache[key]
-        else:
-            if len(_duration_array_cache) > 100: _duration_array_cache.clear()
-            _duration_array_cache[key] = duration_array = np.arange(-start+1, years+1, dtype=float)
-        return duration_array
+        return np.arange(-self._start+1, self._years+1, dtype=float)
+
+    def _get_inflation_factors(self):
+        """Multiplicative nominal escalation factors aligned with the cashflow array"""
+        n_year = np.arange(self._start + self._years)
+        return (1.0 + self.inflation_rate)**n_year
 
     def _get_depreciation_array(self):
         key = self._depreciation_key
@@ -839,15 +793,15 @@ class TEA:
 
     def get_cashflow_table(self):
         """
-        Return DataFrame of the cash flow analysis.
-
+        Return DataFrame of the cash flow analysis. 
+        
+        Notes
+        -----
         If `inflation_rate` is provided annual, annual costs, sales, capital expenses,
         replacement costs and working capital are reported in nominal dollars.
         Discount factors are computed using the nominal discount rate derived from
         the real `IRR` and `inflation_rate`.
-
-        If `inflation_rate` is None, values are reported in real or base-year dollars and
-        discounted directly with `IRR`.
+        
         """
         # Cash flow data and parameters
         # index: Year since construction until end of venture
@@ -874,7 +828,7 @@ class TEA:
         FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
-        f_inflation = self.inflation_factors
+        inflation_factors = self._get_inflation_factors()
         FOC = self._FOC(FCI)
         VOC = self.VOC
         sales = self.sales
@@ -892,26 +846,25 @@ class TEA:
         start1 = end_start + 1
         C[start1:] = VOC + FOC
         S[start1:] = sales
-        C *= f_inflation
-        S *= f_inflation
+        C *= inflation_factors
+        S *= inflation_factors
         WC = self.WC_over_FCI * FCI
         C_D[:start] = TDC0*self._construction_schedule
-        C_D *= f_inflation
+        C_D *= inflation_factors
         self._fill_depreciation_array(D, start, years, C_D[:start].sum())
-        C_FC[:start] = FCI*self._construction_schedule
-        C_WC[start-1] = WC
+        C_FC[:start] = FCI * self._construction_schedule
+        C_WC[start - 1] = WC * inflation_factors[start - 1]
         C_WC[-1] = -WC
-        C_WC *= f_inflation
         system = self.system
         lang_factor = system.lang_factor
         unit_capital_costs = system.unit_capital_costs.values() if isinstance(system, bst.AgileSystem) else system.cost_units
         for i in unit_capital_costs: add_all_replacement_costs_to_cashflow_array(i, C_FC, years, start, lang_factor)
-        C_FC *= f_inflation
+        C_FC *= inflation_factors
         if self.finance_interest:
             interest = self.finance_interest
             years = self.finance_years
             end = start + years
-            L[:start] = loan = self.finance_fraction*(C_FC[:start])
+            L[:start] = loan = self.finance_fraction * C_FC[:start]
             accumulate_interest_during_construction = self.accumulate_interest_during_construction
             if accumulate_interest_during_construction:
                 initial_loan_principal = loan_principal_with_interest(loan, interest)
@@ -946,7 +899,7 @@ class TEA:
         )
         NE[:] = taxable_cashflow + I - T
         CF[:] = NE + nontaxable_cashflow
-        DF[:] = 1/(1.+self._get_discount_rate())**self._get_duration_array()
+        DF[:] = 1 / (1. + self.discount_rate)**self._get_duration_array()
         NPV[:] = CF * DF
         CNPV[:] = NPV.cumsum()
         DF *= 1e6
@@ -957,11 +910,14 @@ class TEA:
     @property
     def NPV(self) -> float:
         """
-        Net present value.
+        Net present value. 
         
-        Uses cashflows consistent with the inflation setting. With inflation, cashflows are
-        nominal and discounted with the internally computed nominal discount rate. without
-        inflation, cashflows are treated as base-year values and discounted with `IRR`.
+        Notes
+        -----
+        With inflation, cashflows are nominal and discounted 
+        with the nominal discount rate. Without inflation, cashflows are
+        treated as base-year values and discounted only with the `IRR`.
+        
         """
         taxable_cashflow, nontaxable_cashflow, depreciation = self._taxable_nontaxable_depreciation_cashflows()
         tax = np.zeros_like(taxable_cashflow)
@@ -972,7 +928,7 @@ class TEA:
             nontaxable_cashflow, tax, depreciation
         )
         cashflow = nontaxable_cashflow + taxable_cashflow + incentives - tax
-        return NPV_at_IRR(self._get_discount_rate(), cashflow, self._get_duration_array())
+        return NPV_at_IRR(self.discount_rate, cashflow, self._get_duration_array())
     
     def _AOC(self, FCI):
         """Return AOC at given FCI"""
@@ -994,7 +950,7 @@ class TEA:
         FCI = self._FCI(TDC0)
         start = self._start
         years = self._years
-        inflation_factors = self.inflation_factors
+        inflation_factors = self._get_inflation_factors()
         TDC_nom = (TDC0 * self.construction_schedule * inflation_factors[:start]).sum()
         FOC = self._FOC(FCI)
         VOC = self.VOC
@@ -1097,24 +1053,25 @@ class TEA:
             return self.AOC - coproduct_sales
     
     def solve_IRR(self, financing=True, bounds=None):
-        """
+        r"""
         Return the real internal rate of return at the break-even point.
-
-        If `inflation_rate` is provided, this method solves IRR for inflated
-        cashflows and the resulting nominal IRR is converted to real IRR applying
-        Fisher equation: real_IRR = (1 + nominal_IRR)/(1 + inflation_rate) - 1.
-
-        If bounds are provided and `inflation_rate` is not None, bounds must be given
-        as nominal IRR values because the solver operates on nominal cashflows.
+        
+        Notes
+        -----
+        If an `inflation_rate` is specified, this method first solves for the nominal 
+        IRR using the inflated cashflows. Then, the nominal IRR is converted 
+        to the real IRR by applying Fisher equation: 
+            
+        $IRR_{real} = (1 + IRR_{nominal}) / (1 + f_{inflation\ rate}) - 1$
 
         """
-        IRR = self._IRR
-
         # Use nominal IRR as initial guess to solve nominal cashflows
-        if self.inflation_rate is not None:
-            IRR = (1 + IRR)*(1 + self.inflation_rate) - 1
-
+        IRR = self._IRR
         if not IRR or np.isnan(IRR) or IRR < 0.: IRR = 0.01
+        inflation_rate = self.inflation_rate
+        if inflation_rate:
+            IRR = IRR_nominal(IRR, inflation_rate)
+            if bounds is not None: bounds = [IRR_nominal(i, inflation_rate) for i in bounds]
         if financing:
             args = (self.cashflow_array, self._get_duration_array())
             if bounds:
@@ -1145,10 +1102,8 @@ class TEA:
             finally:
                 self.finance_fraction, self.finance_interest = financing_values
         
-        # convert nominal IRR to real IRR 
-        if self.inflation_rate is not None:
-            IRR = (1 + IRR)/(1 + self.inflation_rate) - 1
-
+        # Convert nominal IRR back to real IRR.
+        if inflation_rate: IRR = IRR_real(IRR, inflation_rate)
         self._IRR = IRR
         return IRR
         
@@ -1199,12 +1154,14 @@ class TEA:
         Return the required additional sales [USD] to reach the breakeven 
         point (NPV = 0) through cash flow analysis.
 
+        Notes
+        -----
         The returned value is expressed in base-year dollars. If `inflation_rate`
         is provided, this additional sales value is escalated through time using
         `inflation_factors` before calculating NPV.
         
         """
-        discount_factors = (1 + self._get_discount_rate())**self._get_duration_array()
+        discount_factors = (1 + self.discount_rate)**self._get_duration_array()
         sales_coefficients = np.ones_like(discount_factors, dtype=float)
         start = self._start
         sales_coefficients[:start] = 0
@@ -1212,7 +1169,7 @@ class TEA:
         end_start = start + int(self._startup_time)
         sales_coefficients[end_start] = w0 * self.startup_salesfrac + (1. - w0) 
         sales_coefficients[start:end_start] = self.startup_salesfrac
-        sales_coefficients *= self.inflation_factors
+        sales_coefficients *= self._get_inflation_factors()
         taxable_cashflow, nontaxable_cashflow, depreciation = self._taxable_nontaxable_depreciation_cashflows()
         if np.isnan(taxable_cashflow).any():
             warn('nan encountered in cashflow array; resimulating system', category=RuntimeWarning)

--- a/tests/test_tea.py
+++ b/tests/test_tea.py
@@ -413,8 +413,8 @@ def test_tea_with_inflation():
     table = tea.get_cashflow_table()
     factors = (1 + inflation_rate) ** np.arange(tea._start + tea._years)
 
-    assert_allclose(tea.inflation_factors, factors)
-    assert_allclose(tea._get_discount_rate(), nominal_IRR)
+    assert_allclose(tea._get_inflation_factors(), factors)
+    assert_allclose(tea.discount_rate, nominal_IRR)
 
     # Check nominal escalation of representative cashflows.
     assert_allclose(table['Sales [MM$]'].values[0], 0.0)
@@ -429,7 +429,7 @@ def test_tea_with_inflation():
     # Check construction-year capital and final working capital recovery.
     assert_allclose(table['Fixed capital investment [MM$]'].iloc[0], 3.36)
     assert_allclose(table['Working capital [MM$]'].iloc[0], 0.168)
-    assert_allclose(table['Working capital [MM$]'].iloc[-1], -0.168 * factors[-1])
+    assert_allclose(table['Working capital [MM$]'].iloc[-1], -0.168) # Working capital is returned without inflation
 
     # Check nominal discounting.
     assert_allclose(

--- a/tests/test_tea.py
+++ b/tests/test_tea.py
@@ -337,6 +337,118 @@ def test_tea():
             table['Loan principal [MM$]'].iloc[0])
     assert_allclose(total_interest_payment1, total_interest_payment2, atol=1e-4)
 
+def test_tea_with_inflation():
+    cost = bst.decorators.cost
+    bst.CE = CE = bst.design_tools.CEPCI_by_year[2013]
+
+    @cost('Fake scaler', 'Lumped cost', CE=CE, cost=1e6, S=1, n=1, BM=1)
+    class LumpedCost(bst.Unit):
+        '''Does nothing but adding given costs.'''
+        _units = {'Fake scaler': ''}
+        
+        def _design(self):
+            self.design_results['Fake scaler'] = 1
+        
+    class TEA(bst.TEA):
+        def __init__(
+                self,
+                system,
+                FOC_over_installed=0.5,
+                DPI_over_installed=2,
+                TDC_over_DPI=1.2*1.4,
+                FCI_over_TDC=1,
+                **kwargs,
+                ):
+            self.FOC_over_installed = FOC_over_installed
+            self.DPI_over_installed = DPI_over_installed
+            self.TDC_over_DPI = TDC_over_DPI
+            self.FCI_over_TDC = FCI_over_TDC
+            bst.TEA.__init__(self, system, **kwargs)
+    
+        def _FOC(self, installed_equipment_cost):
+            return installed_equipment_cost * self.FOC_over_installed
+        
+        def _DPI(self, installed_equipment_cost):
+            return installed_equipment_cost * self.DPI_over_installed
+    
+        def _TDC(self, DPI):
+            return DPI * self.TDC_over_DPI
+    
+        def _FCI(self, TDC):
+            return TDC * self.FCI_over_TDC
+        
+    bst.settings.set_thermo([bst.Chemical('Water')])
+    reactant = bst.Stream('reactant', Water=1, units='kg/hr')
+    product = bst.Stream('product', Water=1, price=2.5e6/365/24, units='kg/hr')
+    
+    U101 = LumpedCost('U101', ins=reactant, outs=product)
+    sys = bst.System('sys_inflation', path=(U101,))
+    sys.simulate()
+
+    IRR = 0.10
+    inflation_rate = 0.03
+    nominal_IRR = (1 + IRR) * (1 + inflation_rate) - 1
+
+    tea = TEA(
+        system=sys,
+        IRR=IRR,
+        inflation_rate=inflation_rate,
+        duration=(2013, 2013+15),
+        income_tax=0.31,
+        construction_schedule=(1,),
+        depreciation='MACRS7',
+        operating_days=365,
+        startup_months=0,
+        startup_FOCfrac=1,
+        startup_VOCfrac=1,
+        startup_salesfrac=1,
+        lang_factor=None,
+        WC_over_FCI=0.05,
+        finance_interest=0.08,
+        finance_years=10,
+        finance_fraction=0.6,
+        accumulate_interest_during_construction=False,
+    )
+
+    table = tea.get_cashflow_table()
+    factors = (1 + inflation_rate) ** np.arange(tea._start + tea._years)
+
+    assert_allclose(tea.inflation_factors, factors)
+    assert_allclose(tea._get_discount_rate(), nominal_IRR)
+
+    # Check nominal escalation of representative cashflows.
+    assert_allclose(table['Sales [MM$]'].values[0], 0.0)
+    assert_allclose(table['Sales [MM$]'].values[1:], 2.5 * factors[1:])
+
+    assert_allclose(table['Annual operating cost (excluding depreciation) [MM$]'].values[0], 0.0)
+    assert_allclose(
+        table['Annual operating cost (excluding depreciation) [MM$]'].values[1:],
+        1.68 * factors[1:],
+    )
+
+    # Check construction-year capital and final working capital recovery.
+    assert_allclose(table['Fixed capital investment [MM$]'].iloc[0], 3.36)
+    assert_allclose(table['Working capital [MM$]'].iloc[0], 0.168)
+    assert_allclose(table['Working capital [MM$]'].iloc[-1], -0.168 * factors[-1])
+
+    # Check nominal discounting.
+    assert_allclose(
+        table['Discount factor'],
+        1 / (1 + nominal_IRR) ** tea._get_duration_array(),
+    )
+
+    # Table and NPV property should be consistent.
+    assert_allclose(
+        tea.NPV,
+        table['Cumulative NPV [MM$]'].iloc[-1] * 1e6,
+        atol=1e-4,
+    )
+
+    # Check solve_price with inflation; indirectly checks solve_sales.
+    price = tea.solve_price(product)
+    product.price = price
+    assert_allclose(tea.NPV, 0, atol=100)
+
 def test_add_replacement_cost():
     cashflow_array = np.zeros(12)
 
@@ -358,5 +470,6 @@ if __name__ == '__main__':
     test_depreciation_schedule()
     test_cashflow_consistency()
     test_tea()
+    test_tea_with_inflation()
     test_tea_startup_months()
     test_add_replacement_cost()


### PR DESCRIPTION
This PR adds optional inflation handling to the TEA object. It allows selected cashflows to be escalated over time and enables inflation-aware cashflow-based metrics.

## Considerations

The implementation follows these conventions:

1. `IRR` is provided as a real internal rate of return. If `inflation_rate` is provided, it is internally converted to a nominal discount rate for NPV calculations using:

   ```python
   nominal_IRR = (1 + IRR) * (1 + inflation_rate) - 1
   ```
2. `inflation_rate` is an annual constant inflation rate applied to CAPEX, OPEX, sales, replacement costs and working capital.
3. Inflation is applied considering the first construction year as the base-year.
4. Depreciation is calculated from the inflated CAPEX basis. This means depreciation is based on historical nominal capital expenditure and is not escalated year-by-year with inflation.
5. `finance_interest` is interpreted as a nominal financing interest rate when inflation is considered.
6. When `inflation_rate`, the original behavior is preserved: cashflows are treated as base-year values and discounted directly with `IRR`.

## Implementation details
A new optional argument was added to `TEA.__init__`:

  ```python
  inflation_rate : float | None = None
  ```

When `inflation_rate = None` which is the default option, all inflation factors are equal to 1.0. Therfore, original cashflow behavior is preserved. In constract, when `inflation_rate` is provided/changed, or when `construction_schedule` or/and `duration` are modified, `inflation_factors` are recalculated and updated.

The inflation factors are applied to the main cashflow components before calculating taxes, financing and NPV. Specifically, inflation is applied to:

- annual operating costs
- sales
- fixed capital investment
- depreciable capital
- replacement costs
- working capital cashflows

Only a global inflation rate is currently considered. Future work could extend this implementation to support different inflation rates for individual cashflow categories, such as FOC, VOC, sales, equipment costs, replacement costs, and working capital. This was not implemented here because the current biorefinery models I use, consider a single global inflation rate. In addition, the reference used for this implementation, Plant Design and Economics for Chemical Engineers by Peters, Timmerhaus and West, recommended global inflation rates such as consumer price index.

Metrics based on cashflow analysis are calculated using nominal values when inflation is active. Other metrics, such as `production_costs`, `net_earnings` and `installed_equipment_cost`, are kept as base-year values. This is intentional because accounting for the time value of money is only meaningful when a time-dependent cashflow analysis is being performed.

## Tests
Backward compatibility is checked through the existing `test_tea`, which does not include inflation because the default value of `inflation_rate` is `None`.

A new test, `test_tea_with_inflation`, was added to verify the inflation implementation using the same model structure as `test_tea`. This test checks that:

- inflation factors are correctly generated.
- relevant cashflows are properly escalated.
- the nominal discount rate is calculated from `IRR` and `inflation_rate`.
- `get_cashflow_table()` and NPV remain consistent.
- `solve_price()` works with inflation and returns a price that results in approximately zero NPV.