### PR TITLE
Fix bug for reactor batch calculation.

### DIFF
--- a/biosteam/units/design_tools/batch.py
+++ b/biosteam/units/design_tools/batch.py
@@ -173,15 +173,6 @@ def size_batch(F_vol, tau_reaction, tau_cleaning, V_wf,
             N_reactors = ceil(F_vol * (tau_reaction + tau_cleaning + tau_loading) / (V_max * V_wf))
             V_T = F_vol * (tau_reaction + tau_cleaning + tau_loading)
             V_i = V_T / N_reactors
-            
-            # Total volume of all reactors, assuming no downtime
-            V_T = F_vol * (tau_reaction + tau_cleaning) / (1 - 1 / N_reactors)
-            
-            # Volume of an individual reactor
-            V_i = V_T / N_reactors
-            
-            # Time required to load a reactor
-            tau_loading = V_i / F_vol
 
         # Total volume of all reactors, assuming no downtime
         V_T = F_vol * (tau_reaction + tau_cleaning) / (1 - 1 / N_reactors)

--- a/biosteam/units/design_tools/batch.py
+++ b/biosteam/units/design_tools/batch.py
@@ -182,6 +182,15 @@ def size_batch(F_vol, tau_reaction, tau_cleaning, V_wf,
             
             # Time required to load a reactor
             tau_loading = V_i / F_vol
+
+        # Total volume of all reactors, assuming no downtime
+        V_T = F_vol * (tau_reaction + tau_cleaning) / (1 - 1 / N_reactors)
+
+        # Volume of an individual reactor
+        V_i = V_T / N_reactors
+
+        # Time required to load a reactor
+        tau_loading = V_i / F_vol
     else:
         tau_loading = loading_time
         


### PR DESCRIPTION
The original script didn't account for scenarios where `loading_time` is None but `N_reactors` is given. Happen to be the case for one EXPOsan system.